### PR TITLE
Generalize

### DIFF
--- a/doc/composition.rst
+++ b/doc/composition.rst
@@ -1,0 +1,99 @@
+Plasma Composition
+======================
+
+This section of the documentation describes the main concepts of the modules dedicated to the calculation of the plasma composition.
+
+
+Documentation and Publications
+------------------------------------------
+
+| The main features of the code in its various versions since its initial conception are documented in the following papers:
+| `M. Sertoli et al. J. Plasma Phys. 85, 905850504 (2019) <https://doi.org/10.1017/S0022377819000618>`_
+| `M. Sertoli et al. Review of Scientific Instruments 89, 113501 (2018) <https://doi.org/10.1063/1.5046562>`_
+| `M. Sertoli et al. Plasma Phys. Control. Fusion 57 075004 (2015) <https://doi.org/10.1088/0741-3335/57/7/075004>`_
+
+| Other publications in which the results of the method have been used are:
+| `F.J. Casson et al.  Nucl. Fusion in press 2020 <https://doi.org/10.1088/1741-4326/ab833f>`_
+| `A. Field et al. Plasma Phys. Control. Fusion 62 055010 (2020)  <https://doi.org/10.1088/1361-6587/ab7942>`_
+| `S. Gloeggler et al. Nuclear Fusion 59, 126031 (2019) <https://doi.org/10.1088/1741-4326/ab3f7a>`_
+| `O. Lindner et al. Nuclear Fusion 59, 016003 (2018) <https://doi.org/10.1088/1741-4326/aae875>`_
+| `S. Breton et al. Nuclear Fusion 58, 096003 (2018) <https://doi.org/10.1088/1741-4326/aac780>`_
+| `S. Breton et al. Physics of Plasmas 25, 012303 (2018) <https://doi.org/10.1063/1.5019275>`_
+| `C. Angioni et al. Nuclear Fusion 57, 056015 (2017) <https://doi.org/10.1088/1741-4326/aa6453>`_
+| `C. Angioni et al. Physics of Plasmas 24, 112503 (2017) <https://doi.org/10.1088/1741-4326/aa6453>`_
+| `M. Goniche et al. Plasma Physics and Controlled Fusion 59, 055001 (2017) <https://doi.org/10.1088/1361-6587/aa60d2>`_
+| `M. Sertoli et al. Nuclear Fusion 55, 113029 (2015) <https://doi.org/10.1088/0029-5515/55/11/113029>`_
+| `P. Piovesan et al. Plasma Physics and Controlled Fusion 59, 014027 (2016) <https://doi.org/10.1088/0741-3335/59/1/014027>`_
+
+Scope, Inputs and Outputs
+------------------------------------------
+The main scope of the code is to evaluate the plasma composition combining a large set of measurements from different diagnostics. The code calculates the time evolution of the density profiles of 3(+1) impurities: one low-Z and two mid-/high-Z elements (+ one additional background low-Z impurity, constant in time). Mid-Z and high-Z elements are resolved in 2D on a poloidal plane to account for poloidal asymmetries.
+
+The main inputs necessary for the computation are:
+
+* equilibrium information and flux-surface mapping libraries
+* atomic data (ionization balance and radiative loss parameters)
+* diagnostic data for the following quantities:
+	* electron temperature and density profiles
+	* ion temperature and toroidal rotation
+	* SXR radiation
+	* total radiation
+	* effective charge
+	* passive spectroscopy impurity concentration measurements
+	* fast magnetic measurement (for MHD investigations)
+
+The output of the code is the time evolution of:
+
+* 2D poloidal maps of the mid-Z and high-Z impurities (e.g. Ni and W, for JET)
+* Concentration of the low-Z impurities
+* Zeff profile
+* Main ion density profile (dilution)
+* 2D poloidal map of the total radiation
+
+These resuzlts are checked for consistency against various parameters/measurements including:
+
+* Total radiation vs. bolometry LOS-integrals
+* High-Z poloidal asymmetry vs. measured toroidal rotation
+* Low-Z impurity concentration vs. CXRS measurements
+* High-Z impurity concentration vs. passive spectroscopy estimates
+
+The outputs of the code can be used for further analysis (e.g. the calculation of impurity transport coefficients), comparison with theoretical estimates (e.g. impurity poloidal asymmetries), can be fed into modelling codes (e.g. turbulence modelling, TRANSP modelling), comparison and benchmarking of diagnostic data.
+
+
+Concept
+----------------------------
+
+The concepts behind the code are thoroughly explained in the cited references, but it is useful to summarize here the main assumptions and features:
+
+* The SXR diode diagnostic is the main tool and starting point for the analysis
+* The shape of the SXR emissivity profile is dominated by one high-Z impurity (Z0)
+* An independent measurement (VUV) of the concentration of the main impurity (Z0) is used to re-scale the first guess of its density (optional)
+* A Zeff measurement is used to calculate the concentration of a low-Z impurity (Z1)
+* A second low-Z impurity (Z2) with concentration constant in time can be included
+* Bolometer measurements (LoS-integrals and tomographic reconstructions) are used to cross-check the results and define extrapolation limits beyond the limit of applicability determined by the SXR diagnostic filter function
+* Toroidal rotation measurements or the mode frequency of MHD modes are used to cross-check the poloidal asymmetry of the main high-Z impurity assuming it is governed by centrifugal asymmetries
+* A second high-Z impurity (Z3) can be included, with time evolution identical to Z0, but with scaled peaking following simplified neoclassical theory, asymmetry assuming centrifugal effects and scaled of a fixed multiplication factor for the whole time-range of analysis
+* Calculation of the impurity transport coefficients of the main impurity Z0 using the Gradient-Flux relation on sawtooth cycles.
+* Correlation with MHD activity is performed by analysing:
+
+    * MHD toroidal mode numbers and mode amplitude of core MHD using toroidal magnetic sensors
+    * Sawtooth inversion radius and ICRH resonance layer(s)
+    * 2D reconstruction of the electron temperature from ECE rotational tomography
+    * Profiles of oscillation amplitude and phase of SXR channels due to MHD activity
+
+The inclusion of multiple impurities is performed in a stepwise fashion:
+
+1.	First guess of Z0 re-scaled to the VUV concentration measurement
+2.	Inclusion of Z1 using Zeff
+3.	Calculation of main ion density from quasi-neutrality
+4.	Re-estimation of Z0 using Z1 and main ion contributions to SXR (changes mainly the shape, not much the absolute value because of the rescaling to the VUV Z0 concentration measurement)
+5.	Consistency-check of:
+
+ 	a.	Final estimate of low-Z makes sense (e.g. 10% of Be is way off…)
+	b.	Z0 density asymmetry vs. toroidal rotation or MHD mode frequency
+	c.	Total radiated power (Z0 + Z1 + main ion) vs. LoS-integrals of bolometry
+
+6.	If rotation estimate is wrong, start over with different main impurity Z0
+7.	If shape of LoS-integrals of bolometry misses features on the LFS-midplane, extrapolate to fit the shape
+8.	If missing total radiated power and/or HFS, top/bottom radiation, add Z3 to fill in the gaps
+9.	Perform consistency checks again…

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -3,10 +3,10 @@ Input Data Details
 
 Traceability
 -----------------
-**Data/parameters read from PPF or file must be traceable to its origin**. Raw data should be stored for future referencing, together with their DDA and UID names and SEQ #, or file name for data contained in ASCII/binary files. This ensures tracking of data origin, the possibility to vary calculation/fitting parameters without re-reading the raw data and enables consistency checks vs. derived data e.g.:
+**Data/parameters read from database or file must be traceable to its origin**. Raw data should be stored for future referencing, together with their INSTRUMENT (DDA in JET) and UID user-ID names (e.g. JETPPF, CHAIN1 or any other private UIDs in JET) and REVISION # (SEQ in JET), or file name for data contained in ASCII/binary files. This ensures tracking of data origin, the possibility to vary calculation/fitting parameters without re-reading the raw data and enables consistency checks vs. derived data e.g.:
 
 
-* Demonstrate the quality of the fits to electron/ion profile data (HRTS, LIDAR, KK3, CXRS, etc.);
+* Demonstrate the quality of the fits to electron/ion profile data (Thomson Scattering, ECE, CXRS, etc.);
 
 * Demonstrate goodness of inversion algorithm or forward calculation for line-of-sight (LOS) integrated data (SXR, bolometry, passive spectroscopy, etc.).
 
@@ -15,7 +15,7 @@ Traceability
 
 Time resolution
 -----------------
-**Time resolution required for the analysis is typically 10-50 ms**. Global time array is built given the time window of analysis [t1, t2] and the desired time resolution. All derived quantities are calculated on this axis, which is different from the time resolution of the raw data of each diagnostic which will have to be interpolated accordingly.
+For JET plasmas, the **time resolution required for the analysis is typically 10-50 ms**. Global time array is built given the time window of analysis [t1, t2] and the desired time resolution. All derived quantities are calculated on this axis, which is different from the time resolution of the raw data of each diagnostic which will have to be interpolated accordingly.
 
 
 Reference radial array
@@ -27,16 +27,16 @@ issues: in view of future upgrades, e.g. the inclusion of fast transport codes i
 
 Equilibrium data
 ----------------------
-As all other PPF data, it is saved to a raw-data variable in its original time resolution. When calling the FLUSH library (currently not working in Python 3) for conversion of equilibrium quantities (e.g. (R,z)↔ψ flux), the data is retrieved for the equilibrium time-point in closest proximity to the requested time-point. This pattern has been kept inside the code as well.
+As all other database data, it is saved to a raw-data variable in its original time resolution. For equilibrium quantities and for conversion of equilibrium quantities (e.g. (R,z)↔ψ flux), the data is retrieved for the equilibrium time-point in closest proximity to the requested time-point. This pattern has been kept inside the code as well.
 
 
-Because of uncertainties in equilibrium-calculated geometrical quantities such as separatrix position (uncertainties in magnetic measurements) or magnetic axis position (uncertainties in the plasma pressure at runtime), a possibility of an (R,z) shift of the whole equilibrium should be included. Since shifting the equilibrium is impossible without re-running the equilibrium code, an alternative solution is to shift ALL diagnostic data of the same amount, but in the opposite direction. The (R,z) shift variables should be time-dependent and included in the equilibrium data since it is a quantity that has to be applied equally to all diagnostics.
+Because of uncertainties in equilibrium-calculated geometrical quantities such as separatrix position (uncertainties in magnetic measurements) or magnetic axis position (uncertainties in the plasma pressure at runtime), a possibility of an (R,z) shift of the whole equilibrium is included. Since shifting the equilibrium is impossible without re-running the equilibrium code, an alternative solution is to shift ALL diagnostic data of the same amount, but in the opposite direction. The (R,z) shift variables should be time-dependent and included in the equilibrium data since it is a quantity that has to be applied equally to all diagnostics. This provides a fast way to check the boundary position of the equilibrium reconstruction, but should be used mainly to provide feedback to improve the equilibrium reconstruction.
 
 
 Conversion between coordinates is required for most diagnostic data and equilibrium quantities:
 
 
-* (R,z)↔(rho,t) diagnostics’ measurement positions. For HRTS, LIDAR, CXRS these are local measurements; for KB5 (bolometry), SXR or other line-of-sight (LOS) integrated measurements these are array of values along the LOS. For LOS coordinates, a fixed number of points along all LOS with a constant linear step between points is used to keep a constant spatial resolution along the LOS. Better ways of doing this?
+* (R,z)↔(rho,t) diagnostics’ measurement positions. For Thomson scattering (HRTS, LIDAR in JET) and CXRS these are local measurements; for Bolometric measurements (KB5 in JET), SXR or other line-of-sight (LOS) integrated measurements these are array of values along the LOS. For LOS coordinates, a fixed number of points along all LOS with a constant linear step between points is used to keep a constant spatial resolution along the LOS. Better ways of doing this?
 
 This transformation is also used to calculate a 2D time-dependent poloidal map of rho over a fixed * (R,z) grid used for the 2D maps.
 
@@ -71,19 +71,19 @@ Other quantities that should be read from the equilibrium reconstruction are:
 
 Basic diagnostic data structure
 -------------------------------------------
-Apart from the measured quantity and its estimated error, specific info varies depending on the diagnostic measurement principle. Since the analysis of the data from all diagnostics is performed in an integrated manner on the same equilibrium reconstruction, the raw data should include the least possible derived quantities relying on other PPFs. As an example, the measurement positions of the ECE diagnostic KK3 given in the PPF rely on a specific equilibrium PPF: instead of using these quantities, the frequency of each channel is read and the radial location self-consistently calculated within the code using the common equilibrium reconstruction data.
+Apart from the measured quantity and its estimated error, specific info varies depending on the diagnostic measurement principle. Since the analysis of the data from all diagnostics is performed in an integrated manner on the same equilibrium reconstruction, the raw data should include the least possible derived quantities relying on other database quantities. As an example, the measurement positions of the ECE diagnostic given in the database rely on a specific equilibrium quantities: instead of using these quantities, the frequency of each channel is read and the radial location self-consistently calculated within the code using the common equilibrium reconstruction data.
 
 
 Below is an initial list of information ordered depending on the source (database/file) and details of the diagnostics.
 
 
-* UID, DDA names and SEQ for PPF data e.g. (JETPPF,HRTS,350)
+* UID, INSTRUMENT names and REVISION for database data (e.g. for JET: JETPPF, HRTS, 350)
 
 * File name, path and origin (e.g. name of originator, publication details if published) for ASCII (e.g. ADAS ionization and recombination files), NetCDF (TRANSP) or other file types. Origin is especially important to trace data-files present on a private repository and not available on a central database.
 
-* (R,z) of all local measurement positions (e.g. HRTS, LIDAR, CXRS, magnetic probes, etc.) or (R,z) array of lines-of-sight (e.g. KB5, SXR, KT7/3, KX1, etc.)
+* (R,z) of all local measurement positions (e.g. Thomson scattering, CXRS, magnetic probes, etc.) or (R,z) array of lines-of-sight (e.g. bolometry, SXR, passive spectroscopy, etc.)
 
-* f_channel = acquisition frequency of each channel of the resonators (reflectometry or radiometry diagnostics e.g. KK3, KG10)
+* f_channel = acquisition frequency of each channel of the resonators (reflectometry or radiometry diagnostics e.g. ECE, reflectometry)
 
 * n_harm = harmonic of cyclotron frequency (reflectometry or radiometry diagnostics)
 
@@ -96,27 +96,27 @@ Below is an initial list of information ordered depending on the source (databas
 
 For JET diagnostics, if the information on the LOS or measurement positions is not available in the PPFs, it is taken from the central database built for SURF (RO is David Taylor). It may not be the most optimized database, but it is a standard and is consistent with what users see on the program SURF. The information therein has been checked for most diagnostics with their ROs.
 
-.. _dtype:
+.. _quantity:
 
 List of Data to Read
 --------------------------------------
-Grouped by measurement quantity, the diagnostics (identified with their DDA names) currently included in the program are:
+Grouped by measurement quantity, the diagnostics (identified with their INSTRUMENT names) currently included in the program are:
 
-* Electron density and temperature diagnostics: **HRTS, LIDR, KK3, KG10**
-* Radiation: **SXR, KB5**
-* Spectroscopy: **KS3, KT7/3**
+* Electron density and temperature diagnostics: **Thomson scattering, ECE, reflectometry** (in JET: HRTS, LIDR, KK3, KG10)
+* Radiation: **Bolometry, SXR** (in JET: SXR, KB5)
+* Passive spectroscopy: **Bremsstrahlung, VUV, X-ray crystal** (in JET: KS3, KT7/3, KX1)
 * Charge exchange recombination spectroscopy: **CXRS**
-* Tomographic reconstruction of total radiation: **BOLT, B5NN, B5ML, B5MF**
-* Other tools/diagnostics: **analysis of MHD activity** through FFT and toroidal mode analysis of Mirnov coils, oscillation amplitudes of fast KK3 and SXR.
+* Tomographic reconstruction of total/SXR radiation: **Bolometry, SXR** (in JET: BOLT, B5NN, B5ML, B5MF)
+* Other tools/diagnostics: **analysis of MHD activity** through FFT and toroidal mode analysis of Mirnov coils, oscillation amplitudes of fast ECE and SXR.
 
-Below are the details of the data that has to be read for each of these and other quantities that have to be read or computed for a correct functioning of the program. Most of the diagnostic variables are stored in PPFs of which DDA and DTYPE are specified. When this is not the case, the source of this information will be specified in the column DDA:
+Below are the details of the data that has to be read for each of these and other quantities that have to be read or computed for a correct functioning of the program. Most of the diagnostic variables are stored in database of which INSTRUMENT and QUANTITY (DTYPE in JET) are specified. When this is not the case, the source of this information will be specified in the column INSTRUMENT:
 
 * **Surf** = external databases to read LOS coordinates
 * **Flush** = libraries for reading specific attributes of the equilibrium of mapping between coordinates
 * **ASCII** = for quantities stored in ASCII files
 * **User** = user-defined quantities
 
-and DTYPE will simply be a variable name.
+and QUANTITY will simply be a variable name.
 
 For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno.viola@ukaea.uk>`_ . The Surf database is a publicly available ASCII file */home/flush/surf/input/overlays_db.dat* and maintained by `David Taylor <David.Taylor@ukaea.uk>`_.
 
@@ -127,8 +127,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	* 	- EFIT
@@ -176,8 +176,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	* 	- HRTS, LIDR
@@ -205,8 +205,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	*	- KK3
@@ -236,8 +236,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	*	- KG10
@@ -258,8 +258,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	* 	- KY6
@@ -274,8 +274,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	*	- SXR
@@ -291,8 +291,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	*	- BOLO
@@ -312,8 +312,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	* 	- KS3
@@ -329,8 +329,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	* 	- XCS
@@ -346,8 +346,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	* 	- KT7D
@@ -367,11 +367,11 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
-	* 	- Many DDAs, e.g. CXG6
+	* 	- Many INSTRUMENTs, e.g. CXG6
 		- TI
 		- x, t
 		- Ion temperature (eV), x_cxrs is an *effective* position of measurement in the torus frame (m), but the correct R is RPOS (see below)
@@ -420,8 +420,8 @@ For Flush there is currently a Python 3 wrapper developed by `Bruno Viola <bruno
 	:widths: 5 15 10 60
 	:header-rows: 1
 
-	* 	- DDA
-		- DTYPE
+	* 	- INSTRUMENT
+		- QUANTITY
 		- Axes
 		- Description
 	*	- C1M- (JPF nodes)

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -321,7 +321,7 @@ defined for each data source/format. These return collections of
    abstract class DataReader {
    + {static} NAMESPACE: (str, str)
    - {static} _AVAILABLE_QUANTITIES: dict
-   + {abstract} DDA_METHODS: dict
+   + {abstract} INSTRUMENT_METHODS: dict
    - {abstract} _IMPLEMENTATION_QUANTITIES: dict
    __
    + get(uid: str, instrument: str, revision: int,
@@ -340,7 +340,7 @@ defined for each data source/format. These return collections of
 
    class PPFReader {
    + NAMESPACE: (str, str)
-   + {static} DDA_METHODS
+   + {static} INSTRUMENT_METHODS
    - {static} _IMPLEMENTATION_QUANTITIES: dict
    - _client: SALClient
    __
@@ -369,7 +369,7 @@ dictionary which maps from instrument names to more dictionaries. This
 second layer of dictionaries maps from the names of available
 quantities for that instrument to the :ref:`data type of each one
 <Data Value Type System>`. Subclasses should also provide a dictionary
-called ``DDA_METHODS`` which maps from instrument names to the
+called ``INSTRUMENT_METHODS`` which maps from instrument names to the
 particular method needed to retrieve the data for that
 instrument. This is needed for the general
 :py:meth:`~indica.readers.DataReader.get` method to work. Finally, the

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -138,8 +138,8 @@ return. Not all reader classes need to implement all diagnostics.
 
 For each diagnostic you implement, you must provide some information
 on the sort of data it can return. First, you should define a
-static/class-level attribute ``DDA_METHODS``, which is a dictionary
-mapping between DDA names (in the JET parlance; they are the
+static/class-level attribute ``INSTRUMENT_METHODS``, which is a dictionary
+mapping between INSTRUMENT names (in the JET parlance; they are the
 "instrument" argument to the getter methods) and the specific
 get-method used to read that data. In effect, this is defining what
 type of diagnostic each supported instrument provides.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,14 +1,16 @@
-.. conspire documentation master file, created by
+.. InDiCA documentation master file, created by
    sphinx-quickstart on Tue Apr 14 18:20:53 2020.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-InDiCA
+InDicA
 ======
 
-The Integrated Diagnostic Composition Analysis tool is a library for
-iteratively determining what species are present in the plasma of a
-fusion reactor.
+The Integrated DiagnostiC Analysis tool is a library for analysing multiple
+diagnostics from fusion experiments in an integrated manner. The first application
+of the framework is the determination of the core plasma composition including up to
+four different impurities, returning 2D poloidal maps of the impurity density profiles,
+radiation, Zeff and dilution in the plasma core.
 
 Contents:
 
@@ -17,7 +19,7 @@ Contents:
 
    installation
    tutorial
-   original
+   composition
    data
    design
    prov_schema

--- a/doc/original.rst
+++ b/doc/original.rst
@@ -106,7 +106,7 @@ In this section, the steps of code execution are outlined in detail. The names u
 
 2. Create reference time axis **t_unfold** with desired resolution dt in range tr.
 
-3. **Equilibrium UID and DDA** : define equilibrium diagnostic and read diagnostic-independent geometric quantities often used throughout the code (DTYPES details given in section :ref:`dtype`):
+3. **Equilibrium UID and INSTRUMENT** : define equilibrium diagnostic and read diagnostic-independent geometric quantities often used throughout the code (DTYPES details given in section :ref:`dtype`):
 
 	* **rho(nx)**: define reference time-independent normalized radial coordinate array (currently rho-poloidal, radial resolution nx=101 points)
 	* **R_2D(nx_Rz), z_2D(nx_Rz)**: define time-independent R and z arrays for mapping quantities in 2D on the poloidal plane (currently spatial resolution nRz = 100)
@@ -172,7 +172,7 @@ In this section, the steps of code execution are outlined in detail. The names u
 		c) **Fit all LOS using equation 1** of | `M. Sertoli et al. Review of Scientific Instruments 89, 113501 (2018) <https://doi.org/10.1063/1.5046562>`_ searching for the best profiles of **ϵ_SXR(ρ,R_0;t)** and **λ_SXR(ρ;t)**. The local emissivity calculated in b) is used as starting point for ϵ_SXR, while λ_SXR is set to zero across the full radius. More details of the current fitting method can be found in :ref:`computation`
 
 7. **Define parameters to calculate the plasma composition**
-	* **Choose electron density and temperature diagnostics** with independent input of UID and DDA names for Ne and Te
+	* **Choose electron density and temperature diagnostics** with independent input of UID and INSTRUMENT names for Ne and Te
 	* **Force non-hollow Ne or Te profiles** (bool, default = False) to avoid hollow spline fits of Ne and Te data that could arise simply from sparse central data.
 	* **SXR detection limit** (float, default = 1500): defined as a minimum Te (eV) roughtly coincident with the photon energy of the filter function edge. This limit depends on the thickness of the Be-filter and on the quality of atomic data, so is machine dependent. (*A default is provided and usually works fine, but the user must have the possibility to choose a different radius or temperature limit*)
 	* **Account for Zeff** (bool, default = True): calculate a low-Z impurity density to account for missing contributions to the Zeff measurement (*possible only if a Zeff measurement is available*)

--- a/indica/readers/abstractreader.py
+++ b/indica/readers/abstractreader.py
@@ -50,8 +50,8 @@ class DataReader(BaseIO):
     agent: prov.model.ProvAgent
         An agent representing this object in provenance documents.
         DataArray objects can be attributed to it.
-    DDA_METHODS: Dict[str, str]
-        Mapping between instrument/DDA names and method to use to assemble that
+    INSTRUMENT_METHODS: Dict[str, str]
+        Mapping between instrument (DDA in JET) names and method to use to assemble that
         data. Implementation-specific.
     entity: prov.model.ProvEntity
         An entity representing this object in provenance documents. It is used
@@ -64,9 +64,9 @@ class DataReader(BaseIO):
 
     """
 
-    DDA_METHODS: Dict[str, str] = {}
+    INSTRUMENT_METHODS: Dict[str, str] = {}
     # Mapping between methods for reading data and the quantities which can be
-    # fetched. An implementation may override this for specific DDAs.
+    # fetched. An implementation may override this for specific INSTRUMENTs.
     _AVAILABLE_QUANTITIES: Dict[str, Dict[str, ArrayType]] = {
         "get_thomson_scattering": {
             "ne": ("number_density", "electrons"),
@@ -103,7 +103,7 @@ class DataReader(BaseIO):
             "v": ("luminous_flux", None),
         },
     }
-    # Quantities available for specific DDAs in a given
+    # Quantities available for specific INSTRUMENTs in a given
     # implementation. Override values given in _AVAILABLE_QUANTITIES.
     _IMPLEMENTATION_QUANTITIES: Dict[str, Dict[str, ArrayType]] = {}
 
@@ -173,7 +173,7 @@ class DataReader(BaseIO):
         revision: int = 0,
         quantities: Set[str] = set(),
     ) -> Dict[str, DataArray]:
-        """Reads data for the requested instrument/DDA. In general this will be
+        """Reads data for the requested instrument. In general this will be
         the method you want to use when reading.
 
         Parameters
@@ -194,13 +194,13 @@ class DataReader(BaseIO):
         :
             A dictionary containing the requested physical quantities.
         """
-        if instrument not in self.DDA_METHODS:
+        if instrument not in self.INSTRUMENT_METHODS:
             raise ValueError(
                 "{} does not support reading for instrument {}".format(
                     self.__class__.__name__, instrument
                 )
             )
-        method = getattr(self, self.DDA_METHODS[instrument])
+        method = getattr(self, self.INSTRUMENT_METHODS[instrument])
         if not quantities:
             quantities = set(self.available_quantities(instrument))
         return method(uid, instrument, revision, quantities)
@@ -872,7 +872,7 @@ class DataReader(BaseIO):
         uid
             User ID (i.e., which user created this data)
         instrument
-            Name of the instrument/DDA which measured this data
+            Name of the instrument which measured this data
         revision
             An object (of implementation-dependent type) specifying what
             version of data to get. Default is the most recent.
@@ -968,7 +968,7 @@ class DataReader(BaseIO):
         uid
             User ID (i.e., which user created this data)
         instrument
-            Name of the instrument/DDA which measured this data
+            Name of the instrument which measured this data
         revision
             An object (of implementation-dependent type) specifying what
             version of data to get. Default is the most recent.
@@ -1373,10 +1373,10 @@ class DataReader(BaseIO):
 
     def available_quantities(self, instrument):
         """Return the quantities which can be read for the specified
-        instrument/DDA."""
-        if instrument not in self.DDA_METHODS:
+        instrument."""
+        if instrument not in self.INSTRUMENT_METHODS:
             raise ValueError("Can not read data for instrument {}".format(instrument))
         if instrument in self._IMPLEMENTATION_QUANTITIES:
             return self._IMPLEMENTATION_QUANTITIES[instrument]
         else:
-            return self._AVAILABLE_QUANTITIES[self.DDA_METHODS[instrument]]
+            return self._AVAILABLE_QUANTITIES[self.INSTRUMENT_METHODS[instrument]]

--- a/indica/readers/ppfreader.py
+++ b/indica/readers/ppfreader.py
@@ -87,7 +87,7 @@ class PPFReader(DataReader):
 
     """
 
-    DDA_METHODS = {
+    INSTRUMENT_METHODS = {
         "hrts": "get_thomson_scattering",
         "lidr": "get_thomson_scattering",
         "efit": "get_equilibrium",
@@ -160,7 +160,7 @@ class PPFReader(DataReader):
     def get_sal_path(
         self, uid: str, instrument: str, quantity: str, revision: int
     ) -> str:
-        """Return the path in the PPF database to for the given DDA."""
+        """Return the path in the PPF database to for the given INSTRUMENT (DDA in JET)."""
         return (
             f"/pulse/{self.pulse:d}/ppf/signal/{uid}/{instrument}/"
             f"{quantity}:{revision:d}"
@@ -169,7 +169,7 @@ class PPFReader(DataReader):
     def _get_signal(
         self, uid: str, instrument: str, quantity: str, revision: int
     ) -> Tuple[Signal, str]:
-        """Gets the signal for the given DDA, at the given revision."""
+        """Gets the signal for the given INSTRUMENT (DDA in JET), at the given revision."""
         path = self.get_sal_path(uid, instrument, quantity, revision)
         info = self._client.list(path)
         path = self.get_sal_path(
@@ -442,9 +442,9 @@ class PPFReader(DataReader):
                     if qtime not in results:
                         results[qtime] = qval.dimensions[0].data
                 if len(channels) == 0:
-                    # TODO: Try getting information on the DDA, to determine if
+                    # TODO: Try getting information on the INSTRUMENT (DDA in JET), to determine if
                     # the failure is actually due to requesting an invalid
-                    # DDA or revision
+                    # INSTRUMENT (DDA in JET) or revision
                     self._client.list(
                         f"/pulse/{self.pulse:d}/ppf/signal/{uid}/{instrument}:"
                         f"{revision:d}"
@@ -476,10 +476,10 @@ class PPFReader(DataReader):
             "length": {},
             "machine_dims": self.MACHINE_DIMS,
         }
-        los_dda = self._BREMSSTRAHLUNG_LOS[instrument]
+        los_instrument = self._BREMSSTRAHLUNG_LOS[instrument]
         for q in quantities:
             qval, q_path = self._get_signal(uid, instrument, q, revision)
-            los, l_path = self._get_signal(uid, los_dda, "los" + q[-1], revision)
+            los, l_path = self._get_signal(uid, los_instrument, "los" + q[-1], revision)
             if "times" not in results:
                 results["times"] = qval.dimensions[0].data
             results["length"][q] = 1

--- a/indica/writers/abstractwriter.py
+++ b/indica/writers/abstractwriter.py
@@ -54,7 +54,7 @@ class DataWriter(BaseIO):
         uid
             User ID (i.e., user that created or wrote this data)
         name
-            Name to store this data under, such as a DDA
+            Name to store this data under, such as a INSTRUMENT
         data
             The data to be written out. The data will be written as though it
             had been merged into a single :py:class:`xarray.Dataset`

--- a/tests/unit/readers/get_example_ppfs.py
+++ b/tests/unit/readers/get_example_ppfs.py
@@ -14,8 +14,8 @@ import sal.dataclass
 QUANTITIES = itertools.chain(
     # Equilibrium data
     [
-        f"{dda}/{dtype}"
-        for dda, dtype in itertools.product(
+        f"{instrument}/{dtype}"
+        for instrument, dtype in itertools.product(
             ["efit", "eftp"],
             [
                 "f",
@@ -37,15 +37,15 @@ QUANTITIES = itertools.chain(
     ],
     # Thomson scattering
     [
-        f"{dda}/{dtype}"
-        for dda, dtype in itertools.product(
+        f"{instrument}/{dtype}"
+        for instrument, dtype in itertools.product(
             ["hrts"],
             ["ne", "dne", "te", "dte", "z"],
         )
     ],
     [
-        f"{dda}/{dtype}"
-        for dda, dtype in itertools.product(
+        f"{instrument}/{dtype}"
+        for instrument, dtype in itertools.product(
             ["lidr"],
             ["ne", "neu", "te", "teu", "z"],
         )
@@ -62,8 +62,8 @@ QUANTITIES = itertools.chain(
     ["xcs/cnc"],
     # Charge exchange recombination spectroscopy
     [
-        f"{dda}/{dtype}"
-        for dda, dtype in itertools.product(
+        f"{instrument}/{dtype}"
+        for instrument, dtype in itertools.product(
             ["cxg6"],
             [
                 "ti",

--- a/tests/unit/readers/test_ppf_reader.py
+++ b/tests/unit/readers/test_ppf_reader.py
@@ -671,7 +671,7 @@ def test_get_bremsstrahlung_spectroscopy(
     errors,
     max_freqs,
     text(min_size=1),
-    sampled_from(sorted(PPFReader.DDA_METHODS.keys())),
+    sampled_from(sorted(PPFReader.INSTRUMENT_METHODS.keys())),
     revisions,
     lists(text(), min_size=1, unique=True).map(set),
 )
@@ -698,7 +698,7 @@ def test_general_get(
         )
         results = reader.get(uid, instrument, revision, quantities)
         assert isinstance(results, MagicMock)
-        getattr(reader, reader.DDA_METHODS[instrument]).assert_called_once_with(
+        getattr(reader, reader.INSTRUMENT_METHODS[instrument]).assert_called_once_with(
             uid, instrument, revision, quantities
         )
 


### PR DESCRIPTION
Variables referring to DDA have been generalised to INSTRUMENT in order to generalise for machines other than JET.

Documentation updated accordingly. 
Other variations to the documentation:
- Code name: generalised to Integrated DignostiC Analysis since the composition calculation is one (the first) of the possible applications
- Concept and Workflow: since it gives the details of the composition analysis only, title has been changed to Plasma Composition and the sections explaining the old WSX code have been deleted (original.rst file has been kept as is). Once the new composition analysis workflow has been completed, this section can be expanded.

Still TODO: Input data details / List of data to read: this section must be updated to generalise for any machine and to explain how the data dictionary should be build for each diagnostic (Issue added)