### PR TITLE
Marcosertoli/st40reader

### DIFF
--- a/indica/converters/lines_of_sight.py
+++ b/indica/converters/lines_of_sight.py
@@ -295,13 +295,15 @@ def _get_wall_intersection_distances(
     factor[mask] *= -1
     x2_trial = (-b + factor * np.sqrt(b ** 2 - 4 * a * c)) / (2 * a)
     z_trial = z_start + x2_trial * (z_end - z_start)
-
+    x2_opposite = np.zeros_like(x2_trial)
+    if z_start != z_end:
+        x2_opposite = (opposite_z - z_start) / (z_end - z_start)
     x2 = np.where(
         np.logical_and(
             machine_dimensions[1][0] <= z_trial, z_trial <= machine_dimensions[1][1]
         ),
         x2_trial,
-        (opposite_z - z_start) / (z_end - z_start),
+        x2_opposite,
     )
     return x2 * np.sqrt(
         (R_start - R_end) ** 2 + (z_start - z_end) ** 2 + (T_start - T_end) ** 2

--- a/indica/readers/__init__.py
+++ b/indica/readers/__init__.py
@@ -8,6 +8,7 @@ functionality for a different format of data.
 from .abstractreader import DataReader
 from .adas import ADASReader
 from .ppfreader import PPFReader
+from .st40reader import ST40Reader
 from .selectors import choose_on_plot
 from .selectors import DataSelector
 
@@ -15,6 +16,7 @@ __all__ = [
     "ADASReader",
     "DataReader",
     "PPFReader",
+    "ST40Reader",
     "choose_on_plot",
     "DataSelector",
 ]

--- a/indica/readers/abstractreader.py
+++ b/indica/readers/abstractreader.py
@@ -565,9 +565,6 @@ class DataReader(BaseIO):
         database_results = self._get_equilibrium(uid, instrument, revision, quantities)
         diagnostic_coord = "rho_poloidal"
         times = database_results["times"]
-        downsample_ratio = int(
-            np.ceil((len(times) - 1) / (times[-1] - times[0]) / self._max_freq)
-        )
         coords_1d: Dict[Hashable, ArrayLike] = {"t": times}
         dims_1d = ("t",)
         trivial_transform = TrivialTransform()
@@ -637,10 +634,6 @@ class DataReader(BaseIO):
                 attrs=meta,
             ).sel(t=slice(self._tstart, self._tend))
 
-            if downsample_ratio > 1:
-                quant_data = quant_data.coarsen(
-                    t=downsample_ratio, boundary="trim", keep_attrs=True
-                ).mean()
             quant_data.name = instrument + "_" + quantity
             quant_data.attrs["partial_provenance"] = self.create_provenance(
                 "equilibrium",

--- a/indica/readers/abstractreader.py
+++ b/indica/readers/abstractreader.py
@@ -104,6 +104,7 @@ class DataReader(BaseIO):
             "zmag": ("z", "mag_axis"),
             "zbnd": ("z", "separatrix"),
             "ipla": ("current", "plasma"),
+            "wp": ("energy", "plasma"),
         },
         "get_cyclotron_emissions": {
             "te": ("temperature", "electrons"),
@@ -554,7 +555,7 @@ class DataReader(BaseIO):
             A dictionary containing the requested physical quantities.
 
         """
-        dims_1d_quantities = {"psi", "rmag", "zmag", "faxs", "fbnd", "ipla"}
+        dims_1d_quantities = {"psi", "rmag", "zmag", "faxs", "fbnd", "ipla", "wp"}
         separatrix_quantities = {"rbnd", "zbnd"}
         flux_quantities = {"f", "ftor", "vjac", "rmji", "rmjo"}
         available_quantities = self.available_quantities(instrument)
@@ -607,7 +608,6 @@ class DataReader(BaseIO):
                     "{} can not read thomson_scattering data for "
                     "quantity {}".format(self.__class__.__name__, quantity)
                 )
-
             meta = {
                 "datatype": available_quantities[quantity],
                 "transform": trivial_transform
@@ -1298,6 +1298,167 @@ class DataReader(BaseIO):
         quantities: Set[str],
     ) -> Dict[str, Any]:
         """Reads spectroscopic measurements of He-like emission.
+
+        Parameters
+        ----------
+        uid
+            User ID (i.e., which user created this data)
+        instrument
+            Name of the instrument which measured this data
+        revision
+            An object (of implementation-dependent type) specifying what
+            version of data to get. Default is the most recent.
+        quantities
+            Which physical quantitie(s) to read from the database.
+
+        Returns
+        -------
+        A dictionary containing the following items:
+
+        times : ndarray
+            The times at which measurements were taken
+        machine_dims
+            A tuple describing the size of the Tokamak domain. It should have
+            the form ``((Rmin, Rmax), (zmin, zmax))``.
+
+        For each requested quantity, the following items will also be present:
+
+        <quantity> : ndarray
+            The data itself (first axis is time, second channel)
+        <quantity>_error : ndarray
+            Uncertainty in the data
+        <quantity>_records : List[str]
+            Representations (e.g., paths) for the records in the database used
+            to access data needed for this data.
+        <quantity>_Rstart : ndarray
+            Major radius of start positions for lines of sight for this data.
+        <quantity>_Rstop : ndarray
+            Major radius of stop positions for lines of sight for this data.
+        <quantity>_zstart : ndarray
+            Vertical location of start positions for lines of sight for this data.
+        <quantity>_zstop : ndarray
+            Vertical location of stop positions for lines of sight for this data.
+        <quantity>_Tstart : ndarray
+            Toroidal offset of start positions for lines of sight for this data.
+        <quantity>_Tstop : ndarray
+            Toroidal offset of stop positions for lines of sight for this data.
+
+        """
+        raise NotImplementedError(
+            "{} does not implement a '_get_spectroscopy' "
+            "method.".format(self.__class__.__name__)
+        )
+
+
+    def get_interferometry(
+        self,
+        uid: str,
+        instrument: str,
+        revision: int,
+        quantities: Set[str],
+    ) -> Dict[str, DataArray]:
+        """Reads interferometer electron density.
+
+        Parameters
+        ----------
+        uid
+            User ID (i.e., which user created this data)
+        instrument
+            Name of the instrument which measured this data
+        revision
+            An object (of implementation-dependent type) specifying what
+            version of data to get. Default is the most recent.
+        quantities
+            Which physical quantitie(s) to read from the database.
+
+        Returns
+        -------
+        :
+            A dictionary containing the requested data.
+
+        """
+        available_quantities = self.available_quantities(instrument)
+        database_results = self._get_interferometry(
+            uid, instrument, revision, quantities
+        )
+        times = database_results["times"]
+        transform = LinesOfSightTransform(
+            database_results["Rstart"],
+            database_results["zstart"],
+            database_results["Tstart"],
+            database_results["Rstop"],
+            database_results["zstop"],
+            database_results["Tstop"],
+            f"{instrument}",
+            database_results["machine_dims"],
+        )
+        downsample_ratio = int(
+            np.ceil((len(times) - 1) / (times[-1] - times[0]) / self._max_freq)
+        )
+        coords: Dict[Hashable, Any] = {"t": times}
+        dims = ["t"]
+        if database_results["length"] > 1:
+            dims.append(transform.x1_name)
+            coords[transform.x1_name] = np.arange(
+                database_results["length"]
+            )
+        else:
+            coords[transform.x1_name] = 0
+
+        data = {}
+        drop=[]
+        for quantity in quantities:
+            if quantity not in available_quantities:
+                raise ValueError(
+                    "{} can not read interferometry data for quantity {}".format(
+                        self.__class__.__name__, quantity
+                    )
+                )
+            meta = {
+                "datatype": available_quantities[quantity],
+                "error": DataArray(
+                    database_results[quantity + "_error"], coords, dims
+                ).sel(t=slice(self._tstart, self._tend)),
+                "transform": transform,
+            }
+            quant_data = DataArray(
+                database_results[quantity],
+                coords,
+                dims,
+                attrs=meta,
+            ).sel(t=slice(self._tstart, self._tend))
+            if downsample_ratio > 1:
+                quant_data = quant_data.coarsen(
+                    t=downsample_ratio, boundary="trim", keep_attrs=True
+                ).mean()
+                quant_data.attrs["error"] = np.sqrt(
+                    (quant_data.attrs["error"] ** 2)
+                    .coarsen(t=downsample_ratio, boundary="trim", keep_attrs=True)
+                    .mean()
+                    / downsample_ratio
+                )
+            quant_data.name = instrument + "_" + quantity
+            quant_data.attrs["partial_provenance"] = self.create_provenance(
+                "interferometry",
+                uid,
+                instrument,
+                revision,
+                quantity,
+                database_results[quantity + "_records"],
+                drop,
+            )
+            quant_data.attrs["provenance"] = quant_data.attrs["partial_provenance"]
+            data[quantity] = quant_data.indica.ignore_data(drop, transform.x1_name)
+        return data
+
+    def _get_interferometry(
+        self,
+        uid: str,
+        instrument: str,
+        revision: int,
+        quantities: Set[str],
+    ) -> Dict[str, Any]:
+        """Reads interferometer electron density
 
         Parameters
         ----------

--- a/indica/readers/st40reader.py
+++ b/indica/readers/st40reader.py
@@ -274,7 +274,6 @@ class ST40Reader(DataReader):
         direction = np.array([0.175, 0, 0]) - position
         los_start, los_end = self.get_los(position, direction)
         times, _ = self._get_signal(uid, instrument, ":time", revision)
-        # print(f"Times {times}")
         for q in quantities:
             qval, q_path = self._get_signal(
                 uid, instrument, self.QUANTITIES_MDS[instrument][q], revision

--- a/indica/readers/st40reader.py
+++ b/indica/readers/st40reader.py
@@ -1,0 +1,424 @@
+"""Provides implementation of :py:class:`readers.DataReader` for
+reading MDS+ data produced by ST40.
+
+"""
+
+from numbers import Number
+from pathlib import Path
+import pickle
+import stat
+from typing import Any
+from typing import cast
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Union
+import warnings
+
+import numpy as np
+from MDSplus import Connection
+import scipy.constants as sc
+
+from .abstractreader import CACHE_DIR
+from .abstractreader import DataReader
+from .abstractreader import DataSelector
+from .selectors import choose_on_plot
+from .. import session
+from ..datatypes import ELEMENTS_BY_MASS
+from ..utilities import to_filename
+
+
+# SURF_PATH = Path(surf_los.__file__).parent / "surf_los.dat"
+
+
+class MDSError(Exception):
+    """An exception which occurs when trying to read MDS+ data which would
+    not be caught by the lower-level MDSplus library. An example would be
+    failing to find any valid channels for an instrument when each channel
+    is a separate DTYPE.
+
+    """
+
+
+class MDSWarning(UserWarning):
+    """A warning that occurs while trying to read MDS+ data. Typically
+    related to caching in some way.
+
+    """
+
+
+class ST40Reader(DataReader):
+    """Class to read ST40 MDS+ data using MDSplus.
+
+    Parameters
+    ----------
+    times : np.ndarray
+        An ordered array of times to which data will be
+        downsampled/interpolated.
+    pulse : int
+        The ID number for the pulse from which to get data.
+    uid : str
+        The UID for the particular data to be read.
+    server : str
+        The URL for the SAL server to read data from.
+    default_error : float
+        Relative uncertainty to use for diagnostics which do not provide a
+        value themselves.
+    sess : session.Session
+        An object representing the session being run. Contains information
+        such as provenance data.
+
+    Attributes
+    ----------
+    DIAGNOSTIC_QUANTITIES: Dict[str, Dict[str, Dict[str, Dict[str, ArrayType]]]]
+        Hierarchical information on the quantities which are available for
+        reading. These are indexed by (in order) diagnostic name, UID,
+        instrument name, and quantity name. The values of the innermost
+        dictionary describe the physical type of the data to be read.
+    NAMESPACE: Tuple[str, str]
+        The abbreviation and full URL for the PROV namespace of the reader
+        class.
+
+    """
+
+    INSTRUMENT_METHODS = {
+        "efit": "get_equilibrium",
+        "sxr": "get_radiation",
+        "xrcs": "get_helike_spectroscopy",
+    }
+    _IMPLEMENTATION_QUANTITIES = {
+        "kg10": {"ne": ("number_density", "electron")},
+        "sxr": {
+            "h": ("luminous_flux", "sxr"),
+            "t": ("luminous_flux", "sxr"),
+            "v": ("luminous_flux", "sxr"),
+        },
+        "bolo": {
+            "kb5h": ("luminous_flux", "bolometric"),
+            "kb5v": ("luminous_flux", "bolometric"),
+        },
+        "ks3": {
+            "zefh": ("effective_charge", "plasma"),
+            "zefv": ("effective_charge", "plasma"),
+        },
+    }
+
+    _RADIATION_RANGES = {
+        "sxr/h": 17,
+        "sxr/t": 35,
+        "sxr/v": 35,
+        "bolo/kb5h": 24,
+        "bolo/kb5v": 32,
+    }
+    _KK3_RANGE = (1, 96)
+    MACHINE_DIMS = ((0.15, 0.9), (-0.9, 0.9))
+    UIDS_MDS = {"efit":"", "xrcs":"sxr"}
+    QUANTITIES_MDS = {
+        "efit": {
+            "f": ".profiles.psi_norm:f",
+            "faxs": ".global:faxs",
+            "fbnd": ".global:fbnd",
+            "ftor": ".profiles.psi_norm:ftor",
+            "rmji": ".profiles.psi_norm:rmji",
+            "rmjo": ".profiles.psi_norm:rmjo",
+            "psi": ".psi2d:psi",
+            "vjac": ".profiles.psi_norm:vjac",
+            "rmag": ".global:rmag",
+            "rbnd": ".p_boundary:rbnd",
+            "zmag": ".global:zmag",
+            "zbnd": ".p_boundary:zbnd",
+        },
+        "xrcs":{
+            "te_kw":".te_kw:te",
+            "te_n3w":".te_n3w:te" ,
+            "ti_w":".ti_w:ti" ,
+            "ti_z":".ti_z:ti" ,
+        },
+    }
+# "\\SXR::TOP.XRCS:BEST:BEST_RUN"
+# "\\EFIT::TOP:BEST:BEST_RUN"
+# "\\SPECTROM::TOP.PRINCETON.PASSIVE:BEST:BEST_RUN"
+    def __init__(
+        self,
+        pulse: int,
+        tstart: float,
+        tend: float,
+        server: str = "10.0.40.13",
+        tree: str = "ST40",
+        default_error: float = 0.05,
+        max_freq: float = 1e6,
+        selector: DataSelector = choose_on_plot,
+        session: session.Session = session.global_session,
+    ):
+        self._reader_cache_id = f"st40:{server.replace('-', '_')}:{pulse}"
+        self.NAMESPACE: Tuple[str, str] = ("st40", server)
+        super().__init__(
+            tstart,
+            tend,
+            max_freq,
+            session,
+            selector,
+            pulse=pulse,
+            server=server,
+            default_error=default_error,
+        )
+        self.pulse = pulse
+        self.conn = Connection(server)
+        self.conn.openTree(tree, self.pulse)
+        self._default_error = default_error
+
+    def get_mds_path(
+        self, uid: str, instrument: str, quantity: str, revision: int
+    ) -> str:
+        """Return the path in the MDS+ database to for the given INSTRUMENT/CODE
+
+        uid: currently redundant --> set to empty string ""
+        instrument: e.g. "efit"
+        quantity: e.g. ".global:cr0" # minor radius
+        revision: if 0 --> looks for "best", else "run##"
+        """
+        revision_name = self.get_revision_name(revision)
+        mds_path = ""
+        if len(uid) > 0:
+            mds_path += f".{uid}".upper()
+        mds_path += f".{instrument}.{revision_name}{quantity}".upper()
+        return mds_path, self.mdsCheck(mds_path)
+
+    def _get_signal(
+        self, uid: str, instrument: str, quantity: str, revision: int
+    ) -> Tuple[np.array, str]:
+        """Gets the signal for the given INSTRUMENT, at the
+        given revision."""
+        path, path_check = self.get_mds_path(uid, instrument, quantity, revision)
+        # print(path)
+        data = np.array(self.conn.get(path_check))
+        return data, path
+
+    def _read_cached_ppf(self, path: Path) -> Optional[np.array]:
+        """Check if the PPF data specified by `sal_path` has been cached and,
+        if so, load it.
+
+        """
+        if not path.exists():
+            return None
+        permissions = stat.filemode(path.stat().st_mode)
+        if permissions[5] == "w" or permissions[8] == "w":
+            warnings.warn(
+                "Can not open cache file which is writeable by anyone other than "
+                "the user. (Security risk.)",
+                PPFWarning,
+            )
+            return None
+        with path.open("rb") as f:
+            try:
+                return pickle.load(f)
+            except pickle.UnpicklingError:
+                warnings.warn(
+                    f"Error unpickling cache file {path}. (Possible data corruption.)",
+                    PPFWarning,
+                )
+                return None
+
+    def _write_cached_ppf(self, path: Path, data: np.array):
+        """Write the given signal, fetched from `sal_path`, to the disk for
+        later reuse.
+
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("wb") as f:
+            pickle.dump(data, f)
+        path.chmod(0o644)
+
+    def _sal_path_to_file(self, sal_path: str) -> Path:
+        """Get the file path which would be used to cache data from the given
+        `sal_path`.
+
+        """
+        return (
+            Path.home()
+            / CACHE_DIR
+            / self.__class__.__name__
+            / to_filename(self._reader_cache_id + sal_path + ".pkl")
+        )
+
+    def _get_equilibrium(
+        self, uid: str, instrument: str, revision: int, quantities: Set[str],
+    ) -> Dict[str, Any]:
+        """Fetch raw data for plasma equilibrium."""
+
+        if len(uid) == 0:
+            uid = self.UIDS_MDS[instrument]
+
+        results: Dict[str, Any] = {}
+        times, _ = self._get_signal(uid, instrument, ":time", revision)
+        psin, _ = self._get_signal(uid, instrument, ".profiles.psi_norm:xpsn", revision)
+        for q in quantities:
+            qval, q_path = self._get_signal(
+                uid, instrument, self.QUANTITIES_MDS[instrument][q], revision
+            )
+            self._set_times_item(results, times)
+            if (
+                len(qval.shape) > 1
+                and q not in {"psi", "rbnd", "zbnd"}
+                and "psin" not in results
+            ):
+                results["psin"] = psin
+            if q == "psi":
+                r, r_path = self._get_signal(uid, instrument, ".psi2d:rgrid", revision)
+                z, z_path = self._get_signal(uid, instrument, ".psi2d:zgrid", revision)
+                results["psi_r"] = r
+                results["psi_z"] = z
+                results["psi"] = qval.reshape((len(results["times"]), len(z), len(r)))
+                results["psi_records"] = [q_path, r_path, z_path]
+            else:
+                results[q] = qval
+                results[q + "_records"] = [q_path]
+
+        return results
+
+    def _get_helike_spectroscopy(
+        self, uid: str, instrument: str, revision: int, quantities: Set[str],
+    ) -> Dict[str, Any]:
+
+        if len(uid) == 0:
+            uid = self.UIDS_MDS[instrument]
+
+        results: Dict[str, Any] = {
+            "length": {},
+            "machine_dims": self.MACHINE_DIMS,
+        }
+
+        # position_instrument = "raw_sxr"
+        # position, position_path = self._get_signal(uid, position_instrument, ".xrcs.geometry:position", -1)
+        # direction, position_path = self._get_signal(uid, position_instrument, ".xrcs.geometry:direction", -1)
+        position = np.array([-0.9345, 0.355, 0])
+        direction = np.array([-0.1635, 0.062, 0]) - position
+        los_start, los_end = self.get_los(position, direction)
+        times, _ = self._get_signal(uid, instrument, ":time", revision)
+        # print(f"Times {times}")
+        for q in quantities:
+            qval, q_path = self._get_signal(
+                uid, instrument, self.QUANTITIES_MDS[instrument][q], revision
+            )
+            # print(f"{q} {qval}")
+            if "times" not in results:
+                results["times"] = times
+            results[q + "_records"] = q_path
+            results[q] = qval.data
+            qval_err, q_path_err = self._get_signal(
+                uid, instrument, self.QUANTITIES_MDS[instrument][q]+"_ERR", revision
+            )
+            if np.array_equal(qval_err, "FAILED"):
+                qval_err = 0.0 * results[q]
+                q_path_err = ""
+            results[q + "_error"] = qval_err
+            results[q + "_error" + "_records"] = q_path_err
+
+        results["length"] = 1
+        results["Rstart"] = np.array([los_start[0]])
+        results["Rstop"] = np.array([los_end[0]])
+        results["zstart"] = np.array([los_start[1]])
+        results["zstop"] = np.array([los_end[1]])
+        results["Tstart"] =np.array([0.]) #los_start[2]])
+        results["Tstop"] = np.array([0.]) #los_end[2]])
+
+        return results
+
+    def close(self):
+        """Ends connection to the SAL server from which PPF data is being
+        read."""
+        del self._client
+
+    @property
+    def requires_authentication(self):
+        """Indicates whether authentication is required to read data.
+
+        Returns
+        -------
+        :
+            True if authenticationis needed, otherwise false.
+        """
+        # Perform the necessary logic to know whether authentication is needed.
+        try:
+            self._client.list("/")
+            return False
+        except AuthenticationFailed:
+            return True
+
+    def authenticate(self, name: str, password: str):
+        """Log onto the JET/SAL system to access data.
+
+        Parameters
+        ----------
+        name:
+            Your username when logging onto Heimdall.
+        password:
+            Your single sign-on password.
+
+        Returns
+        -------
+        :
+            Indicates whether authentication was succesful.
+        """
+        try:
+            self._client.authenticate(name, password)
+            return True
+        except AuthenticationFailed:
+            return False
+
+    def mdsCheck(self, mds_path):
+        """Return FAILED if node doesn't exist or other error
+        Return FAILED if: lenght(data)==1 and data==nan"""
+
+        mds_path_test = (
+            f"_dummy = IF_ERROR (IF ((SIZE ({mds_path})==1), "
+            + f'IF ({mds_path}+1>{mds_path}, {mds_path}, "FAILED"),'
+            + f' {mds_path}), "FAILED")'
+        )
+
+        return mds_path_test
+
+    def get_revision_name(self, revision):
+        """Return string defining RUN## or BEST if revision = 0"""
+
+        if revision < 0:
+            rev_str = ""
+        elif revision == 0:
+            rev_str = "best"
+        elif revision < 10:
+            rev_str = f"run0{int(revision)}"
+        elif revision > 9:
+            rev_str = f"run{int(revision)}"
+
+        return rev_str
+
+    def get_los(self, position, direction):
+        """
+        Return (R, z, T) of start and end of line-of-sight given position and direction
+
+        Parameters
+        ----------
+        position
+            (R, z, T) of LOS starting point
+        direction
+            (delta_R, delta_z, delta_T) direction of LOS
+
+        Returns
+        -------
+            start and end (R, z, T)
+
+        """
+
+        x0, y0, z0 = position
+        x1, y1, z1 = position + direction
+
+        Rstart = np.sqrt(x0 ** 2 + y0 ** 2)
+        Rstop = np.sqrt(x1 ** 2 + y1 ** 2)
+        zstart = z0
+        zstop = z1
+        Tstart = y0
+        Tstop = y1
+
+        return (Rstart, zstart, Tstart), (Rstop, zstop, Tstop)

--- a/indica/readers/st40reader.py
+++ b/indica/readers/st40reader.py
@@ -270,8 +270,8 @@ class ST40Reader(DataReader):
         # position_instrument = "raw_sxr"
         # position, position_path = self._get_signal(uid, position_instrument, ".xrcs.geometry:position", -1)
         # direction, position_path = self._get_signal(uid, position_instrument, ".xrcs.geometry:direction", -1)
-        position = np.array([-0.9345, 0.355, 0])
-        direction = np.array([-0.1635, 0.062, 0]) - position
+        position = np.array([1., 0, 0])
+        direction = np.array([0.175, 0, 0]) - position
         los_start, los_end = self.get_los(position, direction)
         times, _ = self._get_signal(uid, instrument, ":time", revision)
         # print(f"Times {times}")
@@ -298,8 +298,8 @@ class ST40Reader(DataReader):
         results["Rstop"] = np.array([los_end[0]])
         results["zstart"] = np.array([los_start[1]])
         results["zstop"] = np.array([los_end[1]])
-        results["Tstart"] =np.array([0.]) #los_start[2]])
-        results["Tstop"] = np.array([0.]) #los_end[2]])
+        results["Tstart"] =np.array([los_start[2]])
+        results["Tstop"] = np.array([los_end[2]])
 
         return results
 
@@ -318,8 +318,8 @@ class ST40Reader(DataReader):
         # position_instrument = ""
         # position, position_path = self._get_signal(uid, position_instrument, "..geometry:position", -1)
         # direction, position_path = self._get_signal(uid, position_instrument, "..geometry:direction", -1)
-        position = np.array([-0.9345, 0.355, 0])
-        direction = np.array([-0.1635, 0.062, 0.]) - position
+        position = np.array([0.380, -0.925, 0])
+        direction = np.array([0.115, 0.993, 0.]) - position
         los_start, los_end = self.get_los(position, direction)
         times, _ = self._get_signal(uid, instrument, ":time", revision)
         # print(f"Times {times}")
@@ -342,8 +342,8 @@ class ST40Reader(DataReader):
         results["Rstop"] = np.array([los_end[0]])
         results["zstart"] = np.array([los_start[1]])
         results["zstop"] = np.array([los_end[1]])
-        results["Tstart"] =np.array([0.]) #los_start[2]])
-        results["Tstop"] = np.array([0.]) #los_end[2]])
+        results["Tstart"] =np.array([los_start[2]])
+        results["Tstop"] = np.array([los_end[2]])
 
         return results
 
@@ -435,8 +435,8 @@ class ST40Reader(DataReader):
         x0, y0, z0 = position
         x1, y1, z1 = position + direction
 
-        Rstart = np.sqrt(x0 ** 2 + y0 ** 2)
-        Rstop = np.sqrt(x1 ** 2 + y1 ** 2)
+        Rstart = x0 #np.sqrt(x0 ** 2 + y0 ** 2)
+        Rstop = x1 #np.sqrt(x1 ** 2 + y1 ** 2)
         zstart = z0
         zstop = z1
         Tstart = y0


### PR DESCRIPTION
Pull request for **discussion** of new read modules and modifications to enable more generality.

Explanation of mods:

converters/lines_of_sight
- corrected to make calculation possible fr z_start = z_end = 0

readers/__init__
- added st40reader

readers/abstract_reader
- swapped **DDA_METHODS** with **INSTRUMENT_METHODS** to allow for more generality to apply to different machines
- swapped **calculation** for **instrument** for consistency with other readers
- swapped **location_quantities** for dims_1d_quantities** for generality
- included **ipla** (plasma current) as 1d quantity
- created new **get_helike_spectroscopy** function to read results from analysis of He-like spectra measuring Ti and Te from line ratios
- created new **get_interferometry** function to read interferometer data

readers/st40reader
- completely new module to read MDS+ data from Toakamk Energy ST40 tree.