### PR TITLE
Add unit tests for operators

### DIFF
--- a/indica/operators/abstractoperator.py
+++ b/indica/operators/abstractoperator.py
@@ -111,7 +111,7 @@ class Operator(ABC):
                     )
                 else:
                     continue
-            if datatype[0] not in GENERAL_DATATYPES:
+            if datatype[0] and datatype[0] not in GENERAL_DATATYPES:
                 warn(
                     "Operator class {} expects argument {} to have "
                     "unrecognised general datatype '{}'".format(
@@ -119,7 +119,7 @@ class Operator(ABC):
                     ),
                     DatatypeWarning,
                 )
-            if datatype[1] not in SPECIFIC_DATATYPES:
+            if datatype[1] and datatype[1] not in SPECIFIC_DATATYPES:
                 warn(
                     "Operator class {} expects argument {} to have "
                     "unrecognised specific datatype '{}'".format(

--- a/indica/operators/invert_radiation.py
+++ b/indica/operators/invert_radiation.py
@@ -492,6 +492,7 @@ class InvertRadiation(Operator):
         for c, i in zip(unfolded_cameras, integral):
             del c["has_data"]
             i.attrs["datatype"] = ("luminous_flux", self.datatype)
+            i.attrs["transform"] = c.camera.attrs["transform"]
             c["back_integral"] = i
         self.assign_provenance(emissivity)
         self.assign_provenance(results)

--- a/indica/operators/spline_fit.py
+++ b/indica/operators/spline_fit.py
@@ -35,7 +35,8 @@ BoundaryType = Union[str, Tuple[SingleBoundaryType, SingleBoundaryType]]
 
 class Spline:
     """Callable class wrapping a `:class:scipy.interpolate.CubicSpline`
-    object so it will work with DataArrays.
+    object so it will work with DataArrays. It performs interpolation
+    over one dimension, but can do this onto a multidimensional grid.
 
     Parameters
     ----------
@@ -75,7 +76,10 @@ class Spline:
         x2: DataArray,
         t: DataArray,
     ) -> DataArray:
-        """Get the spline values at the locations given by the coordinates.
+        """Get the spline values at the locations given by the
+        coordinates. Although it takes multiple coordinates as
+        arguments, the actual interpolation will only be done along
+        the `dim` specified at instantiation.
 
         Parameters
         ----------
@@ -259,9 +263,9 @@ class SplineFit(Operator):
                 end = start + d.attrs["nchannels"] * nt
                 rho, theta = d.indica.convert_coords(flux_surfaces)
                 resid[start:end] = np.ravel(
-                    (
-                        self.spline(flux_surfaces, rho, theta, times).fillna(0.0) - d
-                    ).isel({d.attrs["transform"].x1_name: g})
+                    (self.spline(flux_surfaces, rho, theta, times).fillna(0.0) - d)
+                    .isel({d.attrs["transform"].x1_name: g})
+                    .transpose("t", d.attrs["transform"].x1_name)
                 )
                 start = end
             # assert np.all(np.isfinite(resid))

--- a/indica/operators/spline_fit.py
+++ b/indica/operators/spline_fit.py
@@ -124,7 +124,7 @@ class SplineFit(Operator):
     """
 
     ARGUMENT_TYPES: List[Union[DataType, EllipsisType]] = [
-        ("rho_poloidal", "plasma"),
+        ("norm_flux_pol", "plasma"),
         ("time", "plasma"),
         (None, None),
         ...,

--- a/indica/utilities.py
+++ b/indica/utilities.py
@@ -128,6 +128,10 @@ def coord_array(coord_vals: ArrayLike, coord_name: str):
         if coord_name == "R"
         else "time"
         if coord_name == "t"
+        else "norm_flux_pol"
+        if coord_name == "rho_poloidal"
+        else "norm_flux_tor"
+        if coord_name == "rho_toroidal"
         else coord_name,
         "plasma",
     )

--- a/indica/utilities.py
+++ b/indica/utilities.py
@@ -158,12 +158,12 @@ def broadcast_spline(
             spline,
             interp_coord,
             input_core_dims=[[]],
-            output_core_dims=[tuple(d if d != "t" else "__new_t" for d in spline_dims)],
-        ).assign_coords(__new_t=spline_coords["t"])
+            output_core_dims=[tuple(d if d != "t" else "__old_t" for d in spline_dims)],
+        ).assign_coords(__old_t=coord_array(spline_coords["t"].data, "__old_t"))
         result = time_outer_product.indica.interp2d(
-            __new_t=interp_coord.coords["t"], method="cubic"
+            __old_t=interp_coord.coords["t"], method="cubic"
         ).assign_coords({k: v for k, v in spline_coords.items() if k != "t"})
-        del result.coords["__new_t"]
+        del result.coords["__old_t"]
         return result
     else:
         return apply_ufunc(

--- a/tests/unit/fake_equilibrium.py
+++ b/tests/unit/fake_equilibrium.py
@@ -138,6 +138,14 @@ class FakeEquilibrium(Equilibrium):
         )
         return rho, t
 
+    def R_hfs(self, rho, t=None, kind="poloidal"):
+        R, _, t = self.spatial_coords(rho, np.pi, t, kind)
+        return R, t
+
+    def R_lfs(self, rho, t=None, kind="poloidal"):
+        R, _, t = self.spatial_coords(rho, 0.0, t, kind)
+        return R, t
+
     def minor_radius(self, rho, theta, t=None, kind="poloidal"):
         if t is None:
             t = self.default_t

--- a/tests/unit/operators/test_invert_radiation.py
+++ b/tests/unit/operators/test_invert_radiation.py
@@ -1,0 +1,93 @@
+import numpy as np
+from xarray import DataArray
+from xarray.testing import assert_allclose
+
+from indica.converters import FluxSurfaceCoordinates
+from indica.converters import TransectCoordinates
+from indica.operators.invert_radiation import EmissivityProfile
+from indica.utilities import coord_array
+from ..fake_equilibrium import FakeEquilibrium
+
+
+fake_equilib = FakeEquilibrium(0.6, 0.0)
+flux_coords = FluxSurfaceCoordinates("poloidal")
+flux_coords.set_equilibrium(fake_equilib)
+
+R_positions = DataArray(
+    np.linspace(0.6, 0.6, 10), coords=[("alpha", np.arange(10))]
+).assign_attrs(datatype=("major_rad", "plasma"))
+z_positions = DataArray(
+    np.linspace(-0.3, 0.3, 10), coords=[("alpha", np.arange(10))]
+).assign_attrs(datatype=("z", "plasma"))
+coords = TransectCoordinates(R_positions, z_positions)
+coords.set_equilibrium(fake_equilib)
+
+knot_locs = coord_array([0.0, 0.5, 0.75, 0.9, 1.0], "rho_poloidal")
+knot_times = coord_array(np.linspace(0.0, 10.0, 6), "t")
+
+
+def sym_func(rho, t):
+    # Need this form of polynomial in order to satisfy boundary conditions
+    return rho ** 3 - 3 * rho ** 2 + 0.2 * t + 2
+
+
+def asym_func(rho, t):
+    return 2 * rho + 0.1 * t
+
+
+def test_emissivity_profile_sym():
+    sym_emiss = sym_func(knot_locs, knot_times)
+    asym_par = 0 * knot_locs
+    profile = EmissivityProfile(sym_emiss, asym_par, flux_coords)
+    rho_grid = coord_array(np.linspace(0.3, 0.7, 9), "rho_poloidal")
+    theta_grid = coord_array(np.linspace(0, 2 * np.pi, 8, False), "theta")
+    t_grid = coord_array(np.linspace(0.5, 9.5, 10), "t")
+    expected_emissiv = sym_func(rho_grid, t_grid) + 0 * theta_grid
+    result = profile(flux_coords, rho_grid, theta_grid, t_grid)
+    assert_allclose(result, expected_emissiv.transpose(*result.dims))
+    assert result.attrs["transform"] == flux_coords
+
+
+def test_emissivity_profile_asym():
+    sym_emiss = 0 * knot_locs * knot_times + 1
+    asym_par = asym_func(knot_locs, knot_times)
+    profile = EmissivityProfile(sym_emiss, asym_par, flux_coords)
+    alpha_grid = R_positions.coords["alpha"]
+    alpha_z_off_grid = 0 * z_positions
+    t_grid = coord_array(np.linspace(0.5, 9.5, 4), "t")
+    rho_grid, theta_grid = coords.convert_to(
+        flux_coords, alpha_grid, alpha_z_off_grid, t_grid
+    )
+    R_0 = fake_equilib.R_hfs(rho_grid, t_grid, "poloidal")[0]
+    expected_emissiv = np.exp(asym_func(rho_grid, t_grid) * (0.36 - R_0 ** 2))
+    result = profile(coords, alpha_grid, alpha_z_off_grid, t_grid)
+    assert_allclose(result, expected_emissiv.transpose(*result.dims))
+    assert result.attrs["transform"] == coords
+
+
+def test_emissivity_profile_evaluate1():
+    sym_emiss = sym_func(knot_locs, knot_times)
+    asym_par = asym_func(knot_locs, knot_times)
+    profile = EmissivityProfile(sym_emiss, asym_par, flux_coords)
+    R_grid = coord_array(np.linspace(0.3, 0.9, 7), "R")
+    z_grid = coord_array(np.linspace(-0.2, 0.2, 5), "z")
+    rho_grid, theta_grid = flux_coords.convert_from_Rz(R_grid, z_grid, 0.0)
+    del rho_grid.coords["t"]
+    expected_emissiv = sym_func(rho_grid, knot_times)
+    result = profile.evaluate(rho_grid, R_grid, R_0=R_grid)
+    assert_allclose(result, expected_emissiv.transpose(*result.dims))
+
+
+def test_emissivity_profile_evaluate2():
+    sym_emiss = sym_func(knot_locs, knot_times)
+    asym_par = asym_func(knot_locs, knot_times)
+    profile = EmissivityProfile(sym_emiss, asym_par, flux_coords)
+    R_grid = coord_array(np.linspace(0.3, 0.9, 7), "R")
+    z_grid = coord_array(np.linspace(-0.2, 0.2, 5), "z")
+    t_grid = coord_array(np.linspace(0.5, 9.5, 4), "t")
+    rho_grid, theta_grid = flux_coords.convert_from_Rz(R_grid, z_grid, t_grid)
+    expected_emissiv = sym_func(rho_grid, t_grid) * np.exp(
+        0.01 * asym_func(rho_grid, t_grid)
+    )
+    result = profile.evaluate(rho_grid, R_grid, R_0=np.sqrt(R_grid ** 2 - 0.01))
+    assert_allclose(result, expected_emissiv.transpose(*result.dims))

--- a/tests/unit/operators/test_spline_fit.py
+++ b/tests/unit/operators/test_spline_fit.py
@@ -1,0 +1,99 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+from xarray import DataArray
+from xarray.testing import assert_allclose
+
+from indica.converters import FluxSurfaceCoordinates
+from indica.converters import TransectCoordinates
+from indica.converters import TrivialTransform
+from indica.operators.spline_fit import Spline
+from indica.operators.spline_fit import SplineFit
+from indica.utilities import coord_array
+from ..fake_equilibrium import FakeEquilibrium
+
+
+# Test the spline class
+
+fake_equilib = FakeEquilibrium(0.6, 0.0)
+
+R_positions = DataArray(
+    np.linspace(1.0, 0.1, 10), coords=[("alpha", np.arange(10))]
+).assign_attrs(datatype=("major_rad", "plasma"))
+z_positions = DataArray(
+    np.linspace(-0.1, 0.2, 10), coords=[("alpha", np.arange(10))]
+).assign_attrs(datatype=("z", "plasma"))
+coords = TransectCoordinates(R_positions, z_positions)
+coords.set_equilibrium(fake_equilib)
+
+trivial = TrivialTransform()
+R_grid = coord_array(np.linspace(0.0, 1.2, 7), "R")
+z_grid = coord_array(np.linspace(-1.0, 1.0, 5), "z")
+t_grid = coord_array(np.linspace(0.0, 10.0, 11), "t")
+
+
+def func(R, z, t):
+    return R - z + 0.5 * t
+
+
+def test_spline_trivial_coords_R():
+    spline = Spline(func(R_grid, z_grid, t_grid), "R", trivial, "natural")
+    R = coord_array(np.linspace(0.2, 0.8, 4), "R")
+    result = spline(trivial, R, z_grid, t_grid)
+    assert_allclose(result, func(R, z_grid, t_grid))
+
+
+def test_spline_trivial_coords_z():
+    spline = Spline(func(R_grid, z_grid, t_grid), "z", trivial, "natural")
+    z = coord_array(np.linspace(-0.2, 0.2, 5), "z")
+    result = spline(trivial, R_grid, z, t_grid)
+    assert_allclose(result, func(R_grid, z, t_grid).transpose(*result.dims))
+
+
+def test_spline_transect_coords_x1():
+    spline = Spline(func(R_grid, 0, t_grid), "R", trivial, "natural")
+    indices = [1, 3, 5]
+    alpha = coord_array(indices, coords.x1_name)
+    alpha_z_offset = coord_array([0.2, 0.1], coords.x2_name)
+    result = spline(coords, alpha, alpha_z_offset, t_grid)
+    assert_allclose(result, func(R_positions[indices], 0.0, t_grid))
+
+
+def test_spline_transect_coords_x2():
+    spline = Spline(func(0, z_grid, t_grid), "z", trivial, "natural")
+    indices = [1, 3, 5]
+    alpha = coord_array(indices, coords.x1_name)
+    alpha_z_offset = coord_array([0.2, 0.1], coords.x2_name)
+    result = spline(coords, alpha, alpha_z_offset, t_grid)
+    assert_allclose(result, func(0, z_positions[indices] + alpha_z_offset, t_grid))
+
+
+# Test the fit itself
+
+
+def test_spline_fit():
+    flux_coords = FluxSurfaceCoordinates("poloidal")
+    flux_coords.set_equilibrium(fake_equilib)
+    knot_locations = [0.0, 0.5, 0.8, 1.05]
+    knot_vals = (
+        DataArray([1.0, 0.9, 0.6, 0.0], coords=[("rho_poloidal", knot_locations)])
+        + 0.05 * t_grid
+    )
+    knot_vals.loc[knot_locations[-1]] = 0.0
+    expected_spline = Spline(knot_vals, "rho_poloidal", flux_coords)
+    input_vals = expected_spline(
+        coords, R_positions.coords["alpha"], 0.0, t_grid
+    ).assign_coords(alpha_z_offset=0)
+    input_vals.attrs["datatype"] = ("temperature", "electron")
+    fitter = SplineFit(knot_locations, sess=MagicMock())
+    result_locations = coord_array(np.linspace(0, 1.05, 10), "rho_poloidal")
+    result, spline_fit, binned_input = fitter(result_locations, t_grid, input_vals)
+    assert_allclose(input_vals, binned_input)
+    assert_allclose(spline_fit, knot_vals.transpose(*spline_fit.dims))
+    assert_allclose(result, expected_spline(flux_coords, result_locations, 0.0, t_grid))
+    assert result.attrs["datatype"] == input_vals.attrs["datatype"]
+    assert isinstance(result.attrs["splines"], Spline)
+    assert result.attrs["transform"] == flux_coords
+    assert "provenance" in result.attrs
+    assert "provenance" in spline_fit.attrs
+    assert "provenance" in binned_input.attrs

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -93,7 +93,7 @@ def test_to_filename_known_result():
 
 # There appears to be a bug in the Hypothesis type annotation for the
 # arrays() strategy
-@given(arrays(float, integers(0, 100)), text())  # typing: ignore
+@given(arrays(float, integers(0, 100)), text())  # type: ignore
 def test_coord_array(vals, name):
     coords = utilities.coord_array(vals, name)
     np.testing.assert_array_equal(coords.data, vals)

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -91,7 +91,9 @@ def test_to_filename_known_result():
     assert utilities.to_filename("a/b/C\\d-e(f, g)") == "a-b-C-d-e(f_g)"
 
 
-@given(arrays(float, integers(0, 100)), text())
+# There appears to be a bug in the Hypothesis type annotation for the
+# arrays() strategy
+@given(arrays(float, integers(0, 100)), text())  # typing: ignore
 def test_coord_array(vals, name):
     coords = utilities.coord_array(vals, name)
     np.testing.assert_array_equal(coords.data, vals)

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -102,6 +102,10 @@ def test_coord_array(vals, name):
         assert datatype[0] == "major_rad"
     elif name == "t":
         assert datatype[0] == "time"
+    elif name == "rho_poloidal":
+        assert datatype[0] == "norm_flux_pol"
+    elif name == "rho_toroidal":
+        assert datatype[0] == "norm_flux_tor"
     else:
         assert datatype[0] == name
     assert datatype[1] == "plasma"
@@ -133,7 +137,7 @@ def test_broadcast_spline_t():
     )
     result = utilities.broadcast_spline(spline, spline_dims, spline_coords, x_interp)
     assert_allclose(result, func_3d(x_interp, y, x_interp.t))
-    assert result.dims == "t", "y"
+    assert result.dims == ("t", "y")
 
 
 def test_broadcast_spline_2d():


### PR DESCRIPTION
I've written unit tests for the SplineFit and InvertRadiation operators. This also involved writing unit tests for the Spline and EmissivityProfile classes which those operators depend on. I also added a few tests for some other previously untested utility functions which I was using. Some of these tests revealed a few minor bugs/corner cases which I hadn't previously considered and which I corrected.

Partially addresses #15.