### PR TITLE
Make PPFReader tests runnable on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ htmlcov/
 .dir-locals.el
 *.pkl
 indica/git_version
+
+!tests/unit/readers/ppf_samples.pkl

--- a/tests/unit/readers/get_example_ppfs.py
+++ b/tests/unit/readers/get_example_ppfs.py
@@ -108,7 +108,7 @@ QUANTITIES = itertools.chain(
     "-c",
     "--channel-stride",
     default=1,
-    help="The inverse of the fractions channels to keep in the data.",
+    help="The inverse of the fractions of channels to keep in the data.",
 )
 @click.option(
     "-t",
@@ -131,9 +131,24 @@ QUANTITIES = itertools.chain(
     help="A pickle file with which initially to populate the dictionary. Only "
     "data not already present in this file will be downloaded.",
 )
+@click.option(
+    "-f",
+    "--fake-data",
+    default=True,
+    help="Whether to overwrite the PPF data with random fake values. This avoids "
+    "sharing proprietary PPF data.",
+)
 @click.argument("output", type=click.File("wb"))
 def get_example_ppfs(
-    pulse, uid, url, channel_stride, max_times, single_precision, sourcefile, output
+    pulse,
+    uid,
+    url,
+    channel_stride,
+    max_times,
+    single_precision,
+    sourcefile,
+    fake_data,
+    output,
 ):
     """Script ot download some PPF data. This is done using the SAL
     interface. SAL Signal objects will be pickled and stored in
@@ -175,6 +190,8 @@ def get_example_ppfs(
             values[q] = thin_data(
                 client.get(path), channel_stride, max_times, single_precision
             )
+            if fake_data:
+                values[q].data = np.random.rand(*values[q].data.shape)
         except sal.core.exception.NodeNotFound:
             print("FAILED! Skipping...")
     # Get data for cyclotron emissions
@@ -189,6 +206,8 @@ def get_example_ppfs(
                 values[key] = thin_data(
                     client.get(path), channel_stride, max_times, single_precision
                 )
+                if fake_data:
+                    values[key].data = np.random.rand(*values[key].data.shape)
             except sal.core.exception.NodeNotFound:
                 print("FAILED! Skipping...")
     pickle.dump(values, output)

--- a/tests/unit/readers/test_ppf_reader.py
+++ b/tests/unit/readers/test_ppf_reader.py
@@ -143,7 +143,6 @@ def test_authentication(fake_sal, pulse, time_range, error, freq, user, password
     edited_revisions,
     lists(sampled_from(["te", "ne"]), min_size=1, unique=True).map(set),
 )
-@settings(report_multiple_bugs=False)
 def test_get_thomson_scattering(
     fake_sal,
     pulse,
@@ -356,6 +355,7 @@ def test_get_equilibrium(
     edited_revisions,
     sane_floats(),
 )
+@settings(deadline=500)
 def test_get_cyclotron_emissions(
     fake_sal,
     pulse,
@@ -445,7 +445,6 @@ def test_get_cyclotron_emissions(
     lists(sampled_from(["h", "t", "v"]), min_size=1, unique=True).map(set),
     lines_of_sight,
 )
-@settings(report_multiple_bugs=False)
 def test_get_sxr(
     fake_sal,
     pulse,

--- a/tests/unit/readers/test_ppf_reader.py
+++ b/tests/unit/readers/test_ppf_reader.py
@@ -40,9 +40,6 @@ from ..strategies import sane_floats
 
 
 FAKE_DATA_PATH = pathlib.Path(__file__).parent.absolute() / "ppf_samples.pkl"
-data_available = pytest.mark.skipif(
-    not FAKE_DATA_PATH.exists(), reason="Fake PPF data not found."
-)
 
 
 @pytest.fixture(scope="module")
@@ -119,7 +116,6 @@ def test_needs_authentication():
         reader._get_thomson_scattering("jetppf", "hrts", 0, {"te"})
 
 
-@data_available
 @given(pulses, times, errors, max_freqs, text(), text())
 def test_authentication(fake_sal, pulse, time_range, error, freq, user, password):
     """Test authentication method on client get called."""
@@ -136,7 +132,6 @@ def test_authentication(fake_sal, pulse, time_range, error, freq, user, password
         reader._client.authenticate.assert_called_once_with(user, password)
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -205,7 +200,6 @@ def test_get_thomson_scattering(
         assert sorted(results[q + "_records"]) == expected
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -272,7 +266,6 @@ def test_get_charge_exchange(
         )
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -351,7 +344,6 @@ def test_get_equilibrium(
             ]
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -441,7 +433,6 @@ def test_get_cyclotron_emissions(
         )
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -522,7 +513,6 @@ def test_get_sxr(
         )
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -589,7 +579,6 @@ def test_get_radiation(
         )
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -664,7 +653,6 @@ def test_get_bremsstrahlung_spectroscopy(
         )
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -703,7 +691,6 @@ def test_general_get(
         )
 
 
-@data_available
 @given(
     pulses,
     times,
@@ -761,7 +748,6 @@ def cachedir():
             ppfreader.CACHE_DIR = old_cache
 
 
-@data_available
 @given(
     pulses,
     times,


### PR DESCRIPTION
PPF data is proprietary, meaning we can not commit it to the repository. This posed a challenge for my approach to testing the PPF reader, as that relied on having a sample of some PPF data in a pickle file (#25). However, I realised that I just need data that is the _right shape_, and the actual values could be overwritten with random numbers. I've modified the script which fetches the data to make that possible and committed a sample of this dummy data to the repository. We will now be able to run these unit tests in CI (which should give a nice boost to code coverage!).
