### PR TITLE
Change Zeff_LoS.attrs[x1_name] to Zeff_LoS.coords[x1_name]

### DIFF
--- a/indica/operators/impurity_concentration.py
+++ b/indica/operators/impurity_concentration.py
@@ -160,7 +160,7 @@ class ImpurityConcentration(Operator):
         x1_name = transform.x1_name
         x2_name = transform.x2_name
 
-        x1 = Zeff_LoS.attrs[x1_name]
+        x1 = Zeff_LoS.coords[x1_name]
         x2_arr = np.linspace(0, 1, 300)
         x2 = DataArray(data=x2_arr, dims=[x2_name])
 

--- a/tests/unit/operators/test_impurity_concentration.py
+++ b/tests/unit/operators/test_impurity_concentration.py
@@ -262,7 +262,7 @@ def test_impurity_concentration():
 
     Zeff_LoS = DataArray(
         data=np.ones(*t.shape) * 1.85,
-        coords={"t": t},
+        coords={"Zeff_LoS_coords": DataArray(data=0), "t": t},
         dims=["t"],
         attrs={
             "transform": LinesOfSightTransform(
@@ -274,7 +274,6 @@ def test_impurity_concentration():
                 y_end=np.array([0.0]),
                 name="Zeff_LoS",
             ),
-            "Zeff_LoS_coords": DataArray(data=np.array([0]), dims=["Zeff_LoS_coords"]),
         },
     )
 


### PR DESCRIPTION
Closes #91 

Fix attempting to access coordinate via attrs instead of coords