### PR TITLE
Fill NaN values in rho array

### DIFF
--- a/indica/operators/impurity_concentration.py
+++ b/indica/operators/impurity_concentration.py
@@ -177,6 +177,7 @@ class ImpurityConcentration(Operator):
                 rho = rho.drop_vars("t")
                 rho = rho.drop_vars("R")
                 rho = rho.drop_vars("z")
+                rho = rho.fillna(2.0)
 
         if set(["R", "z"]).issubset(set(list(impurity_densities.coords.keys()))):
             impurity_densities = impurity_densities.indica.interp2d(


### PR DESCRIPTION
Closes #93 

Replace NaN values in Zeff LOS rho array with invalid rho value (2.0) to fix interpolation crash