### PR TITLE
Prevent adding non-merge commits to master.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     - id: trailing-whitespace
     - id: mixed-line-ending
       name: "Fix Mixed Line Ending"
+    - id: no-commit-to-branch
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:


### PR DESCRIPTION
Fixes #119.

By default this will prevent commits to branches called "master" or "main". Other branches can be added later if desired.