### PR TITLE
Skip no-commit-to-master check in CI.

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,6 +25,8 @@ jobs:
         python-version: 3.8
 
     - name: Lint the code
+      env:
+        SKIP: no-commit-to-branch
       uses: pre-commit/action@v2.0.0
 
   static-analysis:


### PR DESCRIPTION
Should fix linting failing when merging PRs into master after #120 was merged.