### PR TITLE
Add support to ignore known bad channels to channel selector

### DIFF
--- a/indica/readers/selectors.py
+++ b/indica/readers/selectors.py
@@ -170,7 +170,11 @@ def use_cached_ignore_channels(
     return list(unselected_channels)
 
 
-def ignore_channels_from_dict(ignore_dict: Dict[str, List[Number]]) -> Callable:
+def ignore_channels_from_dict(
+    ignore_dict: Dict[str, List[Number]],
+    ignore_bad_channels: bool = False,
+    use_cached_ignore: bool = False,
+) -> Callable:
     """
     Ignore channels from dictionary of {instrument: list of channel} pairs
 
@@ -185,9 +189,27 @@ def ignore_channels_from_dict(ignore_dict: Dict[str, List[Number]]) -> Callable:
         bad_channels: Collection[Number],
         unselected_channels: Iterable[Number] = [],
     ) -> Iterable[Number]:
-        return ignore_dict.get(str(data.name), [])
+        ignore_channels = ignore_dict.get(str(data.name), [])
+        return sorted(
+            set(
+                [
+                    *ignore_channels,
+                    *(bad_channels if ignore_bad_channels is True else []),
+                    *(unselected_channels if use_cached_ignore is True else []),
+                ]
+            )
+        )
 
     return ignore_channels
+
+
+def ignore_bad_channels(
+    data: DataArray,
+    channel_dim: str,
+    bad_channels: Collection[Number],
+    unselected_channels: Iterable[Number] = [],
+) -> Iterable[Number]:
+    return sorted(set([*bad_channels, *unselected_channels]))
 
 
 def ignore_channels_from_file(filename: str) -> Callable:


### PR DESCRIPTION
Fixes #156

Add ignore_bad_channels selector to simply return bad channels

Add option to combine dictionary values with bad channels and/or cached ignore channels in ignore_channels_from_dict, doesn't use either by default