### PR TITLE
Fit asymmetry parameter in optimize_perturbation

### DIFF
--- a/indica/operators/extrapolate_impurity_density.py
+++ b/indica/operators/extrapolate_impurity_density.py
@@ -947,7 +947,7 @@ class ExtrapolateImpurityDensity(Operator):
                     lower_amp_bound,
                     lower_width_bound,
                     lower_pos_bound,
-                    0.1 * asymmetry_parameter.min(),
+                    -10 * np.abs(asymmetry_parameter.max()),
                 ]
             ),
             np.array(
@@ -955,7 +955,7 @@ class ExtrapolateImpurityDensity(Operator):
                     upper_amp_bound,
                     upper_width_bound,
                     upper_pos_bound,
-                    10 * asymmetry_parameter.max(),
+                    10 * np.abs(asymmetry_parameter.max()),
                 ]
             ),
         ]
@@ -966,7 +966,7 @@ class ExtrapolateImpurityDensity(Operator):
                 extrapolated_smooth_data_mean,
                 0.3,
                 1,
-                asymmetry_parameter.mean(),
+                asymmetry_parameter.std(),
             ]
         )
 
@@ -1007,7 +1007,7 @@ class ExtrapolateImpurityDensity(Operator):
                     max_nfev=50,
                     args=(it,),
                     ftol=1e-60,
-                    xtol=1e-3,
+                    xtol=1e-5,
                     gtol=1e-60,
                     x_scale=x_scale,
                 )

--- a/indica/operators/extrapolate_impurity_density.py
+++ b/indica/operators/extrapolate_impurity_density.py
@@ -845,8 +845,9 @@ class ExtrapolateImpurityDensity(Operator):
             Parameters
             ----------
             objective_array
-                List of [amplitude, standard deviation and position] defining the
-                Gaussian perturbation.
+                List of:
+                [amplitude, standard deviation, position and asymmetry_parameter]
+                defining the Gaussian perturbation.
             time
                 Float specifying the time point of interest.
 
@@ -874,6 +875,7 @@ class ExtrapolateImpurityDensity(Operator):
                 rho_poloidal=rho_arr, method="linear"
             )
 
+            # fit asymmetry parameter for region where it was invalid
             asymmetry_parameter_cont = asymmetry_parameter.where(
                 asymmetry_parameter.rho_poloidal > threshold_rho,
                 other=edge_asymmetry_parameter,
@@ -930,6 +932,7 @@ class ExtrapolateImpurityDensity(Operator):
                     extrapolated_smooth_data_mean,
                     np.mean([lower_width_bound, upper_width_bound]),
                     np.mean([lower_pos_bound, upper_pos_bound]),
+                    # asymmetry initial guess is value at threshold
                     asymmetry_parameter.isel(t=0).sel(
                         rho_poloidal=threshold_rho, method="ffill"
                     ),
@@ -956,6 +959,7 @@ class ExtrapolateImpurityDensity(Operator):
             ),
         ]
 
+        # set scale of optimizer steps for amp, width, position and asymmetry
         x_scale = np.array(
             [
                 extrapolated_smooth_data_mean,

--- a/indica/operators/extrapolate_impurity_density.py
+++ b/indica/operators/extrapolate_impurity_density.py
@@ -877,7 +877,7 @@ class ExtrapolateImpurityDensity(Operator):
 
             # fit asymmetry parameter for region where it was invalid
             asymmetry_parameter_cont = asymmetry_parameter.where(
-                asymmetry_parameter.rho_poloidal > threshold_rho,
+                asymmetry_parameter.rho_poloidal < threshold_rho,
                 other=edge_asymmetry_parameter,
             )
             asymmetry_modifier = asymmetry_modifier_from_parameter(

--- a/indica/operators/extrapolate_impurity_density.py
+++ b/indica/operators/extrapolate_impurity_density.py
@@ -767,7 +767,7 @@ class ExtrapolateImpurityDensity(Operator):
         asymmetry_parameter
             Asymmetry parameter used to transform a low-field side only rho-profile
             of a poloidally asymmetric quantity to a full poloidal cross-sectional
-            profile ie. (rho, t) -> (rho, theta, t).
+            profile ie. (rho, t) -> (rho, theta, t). Dimensions (rho, t)
         threshold_rho
             Threshold rho value beyond which asymmetry parameter is invalid and
             should be fitted from bolometry.
@@ -804,10 +804,11 @@ class ExtrapolateImpurityDensity(Operator):
         )
 
         input_check(
-            "asymmetry_modifier",
-            asymmetry_modifier,
+            "asymmetry_parameter",
+            asymmetry_parameter,
             DataArray,
-            ndim_to_check=3,
+            ndim_to_check=2,
+            positive=False,
             strictly_positive=False,
         )
 

--- a/tests/unit/operators/test_extrapolate_impurity_density.py
+++ b/tests/unit/operators/test_extrapolate_impurity_density.py
@@ -931,6 +931,7 @@ def test_extrapolate_impurity_density_call():
     valid_truncation_threshold = initial_data[7]
     flux_surfs = initial_data[6]
     base_t = initial_data[9]
+    R_derived = initial_data[10]
     elements = initial_data[12]
     impurity_sxr_density_asym_Rz = sxr_data[0]
     additional_sig = sxr_data[2]
@@ -955,8 +956,6 @@ def test_extrapolate_impurity_density_call():
         )
     except Exception as e:
         raise e
-
-    example_asym_modifier = example_extrapolate_impurity_density.asymmetry_modifier
 
     perturbed_impurity_sxr_density_rho_theta = (
         example_result_rho_theta.copy(deep=True) + additional_sig
@@ -1025,7 +1024,9 @@ def test_extrapolate_impurity_density_call():
             original_bolometry.copy(deep=True),
             example_bolometry_derivation,
             "w",
-            example_asym_modifier,
+            orig_asymmetry_param,
+            threshold_rho=0.6,
+            R_deriv=R_derived,
             time_correlation=True,
         )
     )


### PR DESCRIPTION
Fixes #169. Fits the asymmetry parameter in the region specified as invalid.