### PR TITLE
Fix CI lint step

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Lint the code
       env:
         SKIP: no-commit-to-branch
-      uses: pre-commit/action@v2.0.0
+      uses: pre-commit/action@v3.0.0
 
   static-analysis:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
     - id: mixed-line-ending
       name: "Fix Mixed Line Ending"
     - id: no-commit-to-branch
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+-   repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
     hooks:
     - id: flake8
       additional_dependencies:


### PR DESCRIPTION
Fixes #203 

Old flake8 repo (on Gitlab) was deleted and replaced with GitHub repo. pre-commit config needed update to reflect this.

Also bumped pre-commit action and flake8.