### PR TITLE
Corrected the rbnd and zbnd calculation

### DIFF
--- a/indica/models/equilibrium.py
+++ b/indica/models/equilibrium.py
@@ -1,11 +1,11 @@
-
+import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 
 from indica.converters import FluxSurfaceCoordinates
 from indica.converters import TrivialTransform
-from indica.equilibrium import Equilibrium
 from indica.converters.time import get_tlabels_dt
+from indica.equilibrium import Equilibrium
 
 MACHINE_DIMS = ((0.15, 0.85), (-0.75, 0.75))
 DEFAULT_PARAMS = {
@@ -43,16 +43,28 @@ def smooth_funcs(domain=(0.0, 1.0), max_val=None):
 
 
 def fake_equilibrium(
-    tstart: float = 0, tend: float = 0.1, dt: float = 0.01, machine_dims=None, times=None,
+    tstart: float = 0,
+    tend: float = 0.1,
+    dt: float = 0.01,
+    machine_dims=None,
+    times=None,
 ):
     equilibrium_data = fake_equilibrium_data(
-        tstart=tstart, tend=tend, dt=dt, machine_dims=machine_dims, times=times,
+        tstart=tstart,
+        tend=tend,
+        dt=dt,
+        machine_dims=machine_dims,
+        times=times,
     )
     return Equilibrium(equilibrium_data)
 
 
 def fake_equilibrium_data(
-    tstart: float = 0, tend: float = 0.1, dt: float = 0.01, machine_dims=None, times=None,
+    tstart: float = 0,
+    tend: float = 0.1,
+    dt: float = 0.01,
+    machine_dims=None,
+    times=None,
 ):
     def monotonic_series(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
         return np.linspace(start, stop, num, endpoint, retstep, dtype)
@@ -71,7 +83,7 @@ def fake_equilibrium_data(
 
     tfuncs = smooth_funcs((tstart, tend), 0.01)
     r_centre = (machine_dims[0][0] + machine_dims[0][1]) / 2
-    z_centre = (machine_dims[1][0] + machine_dims[1][1])/ 2
+    z_centre = (machine_dims[1][0] + machine_dims[1][1]) / 2
     raw_result = {}
     attrs = {
         "transform": TrivialTransform(),
@@ -148,8 +160,8 @@ def fake_equilibrium_data(
     rgrid = xr.DataArray(r, coords=[("R", r)])
     zgrid = xr.DataArray(z, coords=[("z", z)])
     psin = (
-        (-result["zmag"] + zgrid) ** 2 / b_coeff ** 2
-        + (-result["rmag"] + rgrid) ** 2 / a_coeff ** 2
+        (-result["zmag"] + zgrid) ** 2 / b_coeff**2
+        + (-result["rmag"] + rgrid) ** 2 / a_coeff**2
     ) ** (0.5 / n_exp)
 
     psi = psin * (result["fbnd"] - result["faxs"]) + result["faxs"]
@@ -163,9 +175,7 @@ def fake_equilibrium_data(
     psin_coords = np.linspace(0.0, 1.0, nspace)
     rho1d = np.sqrt(psin_coords)
     psin_data = xr.DataArray(psin_coords, coords=[("rho_poloidal", rho1d)])
-    attrs["transform"] = FluxSurfaceCoordinates(
-        "poloidal",
-    )
+    attrs["transform"] = FluxSurfaceCoordinates("poloidal")
     result["psin"] = psin_data
 
     ftor_min = 0.1
@@ -178,21 +188,54 @@ def fake_equilibrium_data(
     )
     result["ftor"].attrs["datatype"] = ("toroidal_flux", "plasma")
 
+    # It should be noted during this calculation that the full extent of theta
+    # isn't represented in the resultant rbnd and zbnd values.
+    # This is because for rbnd: 1/sqrt(tan(x)^2) and for zbnd: 1/sqrt(tan(x)^-2)
+    # are periodic functions which span a fixed 0 to +inf range on the y-axis
+    # between 0 and 2pi, with f(x) = f(x+pi) and f(x) = f(pi-x)
     result["rbnd"] = (
-            result["rmag"]
-            + a_coeff * b_coeff / np.sqrt(a_coeff ** 2 * np.tan(thetas) ** 2 + b_coeff ** 2)
+        result["rmag"]
+        + a_coeff * b_coeff / np.sqrt(a_coeff**2 * np.tan(thetas) ** 2 + b_coeff**2)
     ).assign_attrs(**attrs)
     result["rbnd"].name = "rbnd"
     result["rbnd"].attrs["datatype"] = ("major_rad", "separatrix")
 
     result["zbnd"] = (
-            result["zmag"]
-            + a_coeff
-            * b_coeff
-            / np.sqrt(a_coeff ** 2 + b_coeff ** 2 * np.tan(thetas) ** -2)
+        result["zmag"]
+        + a_coeff
+        * b_coeff
+        / np.sqrt(a_coeff**2 + b_coeff**2 * np.tan(thetas) ** -2)
     ).assign_attrs(**attrs)
     result["zbnd"].name = "zbnd"
     result["zbnd"].attrs["datatype"] = ("z", "separatrix")
+
+    # Indices of thetas for,
+    # 90 <= thetas < 180
+    # 180 <= thetas < 270
+    # 270 <= thetas < 360
+    arcs = {
+        "90to180": np.flatnonzero((0.5 * np.pi <= thetas) & (thetas < 1.0 * np.pi)),
+        "180to270": np.flatnonzero((1.0 * np.pi <= thetas) & (thetas < 1.5 * np.pi)),
+        "270to360": np.flatnonzero((1.5 * np.pi <= thetas) & (thetas < 2.0 * np.pi)),
+    }
+
+    # Transforms rbnd appropriately to represent the values when
+    # 90 <= theta < 180 and 180 <= theta < 270
+    result["rbnd"][:, arcs["90to180"]] = (
+        -result["rbnd"][:, arcs["90to180"]] + 2 * result["rmag"]
+    )
+    result["rbnd"][:, arcs["180to270"]] = (
+        -result["rbnd"][:, arcs["180to270"]] + 2 * result["rmag"]
+    )
+
+    # Transforms zbnd appropriately to represent the values when
+    # 180 <= theta < 270 and 270 <= theta < 360
+    result["zbnd"][:, arcs["180to270"]] = (
+        -result["zbnd"][:, arcs["180to270"]] + 2 * result["zmag"]
+    )
+    result["zbnd"][:, arcs["270to360"]] = (
+        -result["zbnd"][:, arcs["270to360"]] + 2 * result["zmag"]
+    )
 
     if Btot_factor is None:
         f_min = 0.1
@@ -203,8 +246,8 @@ def fake_equilibrium_data(
     else:
         f_raw = np.outer(
             np.sqrt(
-                Btot_factor ** 2
-                - (raw_result["fbnd"] - raw_result["faxs"]) ** 2 / a_coeff ** 2
+                Btot_factor**2
+                - (raw_result["fbnd"] - raw_result["faxs"]) ** 2 / a_coeff**2
             ),
             np.ones_like(rho1d),
         )
@@ -214,13 +257,13 @@ def fake_equilibrium_data(
         f_raw, coords=[("t", times), ("rho_poloidal", rho1d)], name="f", attrs=attrs
     )
     result["f"].attrs["datatype"] = ("f_value", "plasma")
-    result["rmjo"] = (result["rmag"] + a_coeff * psin_data ** n_exp).assign_attrs(
+    result["rmjo"] = (result["rmag"] + a_coeff * psin_data**n_exp).assign_attrs(
         **attrs
     )
     result["rmjo"].name = "rmjo"
     result["rmjo"].attrs["datatype"] = ("major_rad", "lfs")
     result["rmjo"].coords["z"] = result["zmag"]
-    result["rmji"] = (result["rmag"] - a_coeff * psin_data ** n_exp).assign_attrs(
+    result["rmji"] = (result["rmag"] - a_coeff * psin_data**n_exp).assign_attrs(
         **attrs
     )
     result["rmji"].name = "rmji"
@@ -230,7 +273,7 @@ def fake_equilibrium_data(
     result["vjac"] = (
         4
         * n_exp
-        * np.pi ** 2
+        * np.pi**2
         * result["rmag"]
         * a_coeff
         * b_coeff
@@ -246,3 +289,15 @@ def fake_equilibrium_data(
     result["ajac"].attrs["datatype"] = ("area_jacobian", "plasma")
 
     return result
+
+
+if __name__ == "__main__":
+    # Diagnostic example to show that now the full theta extent is
+    # represented in the rbnd and zbnd values.
+    test_equilibrium = fake_equilibrium()
+
+    plt.plot(test_equilibrium.rbnd.isel(t=0), test_equilibrium.zbnd.isel(t=0))
+    plt.xlabel("R")
+    plt.ylabel("z")
+    plt.axis("scaled")
+    plt.show()

--- a/indica/models/plasma.py
+++ b/indica/models/plasma.py
@@ -11,6 +11,7 @@ from indica.converters.time import convert_in_time_dt
 from indica.converters.time import get_tlabels_dt
 from indica.datatypes import ELEMENTS
 from indica.equilibrium import Equilibrium
+from indica.models.equilibrium import fake_equilibrium_data
 from indica.numpy_typing import LabeledArray
 from indica.operators.atomic_data import FractionalAbundance
 from indica.operators.atomic_data import PowerLoss
@@ -21,7 +22,6 @@ from indica.readers import ST40Reader
 from indica.utilities import assign_data
 from indica.utilities import assign_datatype
 from indica.utilities import print_like
-from indica.models.equilibrium import fake_equilibrium_data
 
 plt.ion()
 
@@ -35,8 +35,8 @@ ADF11: dict = {
         "plt": "96",
         "prb": "96",
         "prc": "96",
-        "pls": "15",
-        "prs": "15",
+        # "pls": "15",
+        # "prs": "15",
     },
     "he": {
         "scd": "96",
@@ -45,8 +45,8 @@ ADF11: dict = {
         "plt": "96",
         "prb": "96",
         "prc": "96",
-        "pls": "15",
-        "prs": "15",
+        # "pls": "15",
+        # "prs": "15",
     },
     "c": {
         "scd": "96",
@@ -55,18 +55,18 @@ ADF11: dict = {
         "plt": "96",
         "prb": "96",
         "prc": "96",
-        "pls": "15",
-        "prs": "15",
+        # "pls": "15",
+        # "prs": "15",
     },
     "ar": {
         "scd": "89",
         "acd": "89",
         "ccd": "89",
-        "plt": "00",
-        "prb": "00",
+        "plt": "89",  # "00",
+        "prb": "89",  # "00",
         "prc": "89",
-        "pls": "15",
-        "prs": "15",
+        # "pls": "15",
+        # "prs": "15",
     },
     "ne": {
         "scd": "96",
@@ -75,8 +75,8 @@ ADF11: dict = {
         "plt": "96",
         "prb": "96",
         "prc": "96",
-        "pls": "15",
-        "prs": "15",
+        # "pls": "15",
+        # "prs": "15",
     },
     "mo": {
         "scd": "89",
@@ -93,24 +93,24 @@ ADF11: dict = {
         "plt": "89",
         "prb": "89",
         "prc": "89",
-        "pls": "15",
-        "prs": "15",
+        # "pls": "15",
+        # "prs": "15",
     },
 }
 
 
 class Plasma:
     def __init__(
-            self,
-            tstart: float = 0.01,
-            tend: float = 0.14,
-            dt: float = 0.01,
-            machine_dimensions=((0.15, 0.95), (-0.7, 0.7)),
-            impurities: tuple = ("c", "ar"),
-            main_ion: str = "h",
-            impurity_concentration: tuple = (0.02, 0.001),
-            pulse: int = None,
-            full_run: bool = False,
+        self,
+        tstart: float = 0.01,
+        tend: float = 0.14,
+        dt: float = 0.01,
+        machine_dimensions=((0.15, 0.95), (-0.7, 0.7)),
+        impurities: tuple = ("c", "ar"),
+        main_ion: str = "h",
+        impurity_concentration: tuple = (0.02, 0.001),
+        pulse: int = None,
+        full_run: bool = False,
     ):
         """
         Class for plasma objects.
@@ -355,7 +355,7 @@ class Plasma:
             nz = z_elem + 1
             ion_charges = np.arange(nz)
             data3d_fz = DataArray(
-                np.full((len(self.t), len(self.rho), nz), 0.),
+                np.full((len(self.t), len(self.rho), nz), 0.0),
                 coords=[
                     ("t", self.t),
                     ("rho_poloidal", self.rho),
@@ -371,7 +371,7 @@ class Plasma:
             )
 
     def assign_profiles(
-            self, profile: str = "electron_density", t: float = None, element: str = "ar"
+        self, profile: str = "electron_density", t: float = None, element: str = "ar"
     ):
         if profile == "electron_density":
             self.electron_density.loc[dict(t=t)] = self.Ne_prof()
@@ -391,18 +391,19 @@ class Plasma:
             )
 
     def update_profiles(
-            self,
-            parameters: dict,
-            profile_prefixs: list = [
-                "Te_prof",
-                "Ti_prof",
-                "Ne_prof",
-                "Nimp_prof",
-                "Vrot_prof",
-            ],
+        self,
+        parameters: dict,
+        profile_prefixs: list = [
+            "Te_prof",
+            "Ti_prof",
+            "Ne_prof",
+            "Nimp_prof",
+            "Vrot_prof",
+        ],
     ):
         """
-        Update plasma profiles with profile parameters i.e. {"Ne_prof.y0":1e19} -> Ne_prof.y0
+        Update plasma profiles with profile parameters
+        i.e. {"Ne_prof.y0":1e19} -> Ne_prof.y0
         """
         for param, value in parameters.items():
             _prefix = [pref for pref in profile_prefixs if pref in param]
@@ -516,8 +517,8 @@ class Plasma:
         meanz = self.meanz
         for elem in self.elements:
             self._zeff.loc[dict(element=elem)] = (
-                    (ion_density.sel(element=elem) * meanz.sel(element=elem) ** 2)
-                    / self.electron_density
+                (ion_density.sel(element=elem) * meanz.sel(element=elem) ** 2)
+                / self.electron_density
             ).values
         return self._zeff
 
@@ -565,8 +566,8 @@ class Plasma:
                     self.power_loss_tot[elem](
                         Te, Fz, Ne=Ne, Nh=Nh, bounds_check=False, full_run=self.full_run
                     )
-                        .transpose()
-                        .values
+                    .transpose()
+                    .values
                 )
         return self._lz_tot
 
@@ -590,8 +591,8 @@ class Plasma:
                     self.power_loss_sxr[elem](
                         Te, Fz, Ne=Ne, Nh=Nh, bounds_check=False, full_run=self.full_run
                     )
-                        .transpose()
-                        .values
+                    .transpose()
+                    .values
                 )
         return self._lz_sxr
 
@@ -601,9 +602,9 @@ class Plasma:
         ion_density = self.ion_density
         for elem in self.elements:
             total_radiation = (
-                    lz_tot[elem].sum("ion_charges")
-                    * self.electron_density
-                    * ion_density.sel(element=elem)
+                lz_tot[elem].sum("ion_charges")
+                * self.electron_density
+                * ion_density.sel(element=elem)
             )
             self._total_radiation.loc[dict(element=elem)] = xr.where(
                 total_radiation >= 0,
@@ -621,9 +622,9 @@ class Plasma:
         ion_density = self.ion_density
         for elem in self.elements:
             sxr_radiation = (
-                    lz_sxr[elem].sum("ion_charges")
-                    * self.electron_density
-                    * ion_density.sel(element=elem)
+                lz_sxr[elem].sum("ion_charges")
+                * self.electron_density
+                * ion_density.sel(element=elem)
             )
             self._sxr_radiation.loc[dict(element=elem)] = xr.where(
                 sxr_radiation >= 0,
@@ -703,14 +704,14 @@ class Plasma:
         for elem in self.impurities:
             if np.count_nonzero(self.ion_density.sel(element=elem)) != 0:
                 zeff_tmp = (
-                        self.ion_density.sel(element=elem)
-                        * self.meanz.sel(element=elem) ** 2
-                        / self.electron_density
+                    self.ion_density.sel(element=elem)
+                    * self.meanz.sel(element=elem) ** 2
+                    / self.electron_density
                 )
                 value = zeff_tmp.where(zeff_tmp.rho_poloidal < 0.2).mean("rho_poloidal")
                 zeff_tmp = zeff_tmp / zeff_tmp * value
                 ion_density_tmp = zeff_tmp / (
-                        self.meanz.sel(element=elem) ** 2 / self.electron_density
+                    self.meanz.sel(element=elem) ** 2 / self.electron_density
                 )
                 self.ion_density.loc[dict(element=elem)] = ion_density_tmp.values
 
@@ -749,12 +750,12 @@ class Plasma:
         return binned
 
     def build_atomic_data(
-            self,
-            Te: DataArray = None,
-            Ne: DataArray = None,
-            Nh: DataArray = None,
-            tau: DataArray = None,
-            default=False,
+        self,
+        Te: DataArray = None,
+        Ne: DataArray = None,
+        Nh: DataArray = None,
+        tau: DataArray = None,
+        default=False,
     ):
         if default:
             xend = 1.02
@@ -854,13 +855,13 @@ class Plasma:
             for t in np.array(self.time_to_calculate, ndmin=1):
                 rho = (
                     self.equilibrium.rho.sel(t=t, method="nearest")
-                        .interp(R=R, z=z)
-                        .drop_vars(["R", "z"])
+                    .interp(R=R, z=z)
+                    .drop_vars(["R", "z"])
                 )
                 midplane_profiles[k].append(
                     prof_rho.sel(t=t, method="nearest")
-                        .interp(rho_poloidal=rho)
-                        .drop_vars("rho_poloidal")
+                    .interp(rho_poloidal=rho)
+                    .drop_vars("rho_poloidal")
                 )
             midplane_profiles[k] = xr.concat(midplane_profiles[k], "t").assign_coords(
                 t=self.t
@@ -872,7 +873,7 @@ class Plasma:
         self.midplane_profiles = midplane_profiles
 
     def calc_centrifugal_asymmetry(
-            self, time=None, test_toroidal_rotation=None, plot=False
+        self, time=None, test_toroidal_rotation=None, plot=False
     ):
         """
         Calculate (R, z) maps of the ion densities caused by centrifugal asymmetry
@@ -931,12 +932,12 @@ class Plasma:
             self.centrifugal_asymmetry.loc[dict(element=elem)] = asymm
             asymmetry_factor = asymm.interp(rho_poloidal=self.rho_2d)
             self.asymmetry_multiplier.loc[dict(element=elem)] = np.exp(
-                asymmetry_factor * (self.rho_2d.R ** 2 - R_0 ** 2)
+                asymmetry_factor * (self.rho_2d.R**2 - R_0**2)
             )
 
         self.ion_density_2d = (
-                ion_density.interp(rho_poloidal=self.rho_2d).drop_vars("rho_poloidal")
-                * self.asymmetry_multiplier
+            ion_density.interp(rho_poloidal=self.rho_2d).drop_vars("rho_poloidal")
+            * self.asymmetry_multiplier
         )
         assign_datatype(self.ion_density_2d, ("density", "ion"), "m^-3")
 
@@ -977,9 +978,9 @@ class Plasma:
         """
         for elem in self.elements:
             total_radiation = (
-                    self.lz_tot[elem].sum("ion_charges")
-                    * self.electron_density
-                    * self.ion_density.sel(element=elem)
+                self.lz_tot[elem].sum("ion_charges")
+                * self.electron_density
+                * self.ion_density.sel(element=elem)
             )
             total_radiation = xr.where(
                 total_radiation >= 0,
@@ -989,9 +990,9 @@ class Plasma:
             self.total_radiation.loc[dict(element=elem)] = total_radiation.values
 
             sxr_radiation = (
-                    self.lz_sxr[elem].sum("ion_charges")
-                    * self.electron_density
-                    * self.ion_density.sel(element=elem)
+                self.lz_sxr[elem].sum("ion_charges")
+                * self.electron_density
+                * self.ion_density.sel(element=elem)
             )
             sxr_radiation = xr.where(
                 sxr_radiation >= 0,
@@ -1026,8 +1027,15 @@ class Plasma:
             )
 
 
-def example_run(pulse: int = None, tstart=0.02, tend=0.1, dt=0.01, main_ion="h", impurities=("c", "ar", "he"),
-                impurity_concentration=(0.03, 0.001, 0.01),):
+def example_run(
+    pulse: int = None,
+    tstart=0.02,
+    tend=0.1,
+    dt=0.01,
+    main_ion="h",
+    impurities=("c", "ar", "he"),
+    impurity_concentration=(0.03, 0.001, 0.01),
+):
     # TODO: swap all profiles to new version!
     full_run = False
 
@@ -1093,4 +1101,4 @@ def example_run(pulse: int = None, tstart=0.02, tend=0.1, dt=0.01, main_ion="h",
 
 
 if __name__ == "__main__":
-    example_run()
+    test = example_run()


### PR DESCRIPTION
Closes #213 

Modifies the `rbnd` and `zbnd` calculations so that the values for the full extent of theta are recovered.
Example at the end of `indica/models/equilibrium.py` is purely for diagnostic purposes feel free to remove.

Most if not all of the changes to `indica/models/plasma.py` are due to pre-commit pipeline.