### PR TITLE
Marcosertoli/cxff geometry

### DIFF
--- a/indica/readers/abstractreader.py
+++ b/indica/readers/abstractreader.py
@@ -266,6 +266,23 @@ class DataReader(BaseIO):
             ("t", times),
             ("channel", channels),
         ]
+
+        location = database_results["location"]
+        direction = database_results["direction"]
+        if location is not None and direction is not None:
+            los_transform = LineOfSightTransform(
+                location[:, 0],
+                location[:, 1],
+                location[:, 2],
+                direction[:, 0],
+                direction[:, 1],
+                direction[:, 2],
+                f"{instrument}",
+                database_results["machine_dims"],
+                dl=dl,
+                passes=passes,
+            )
+
         data = {}
         for quantity in quantities:
             quant_data = self.assign_dataarray(
@@ -276,6 +293,8 @@ class DataReader(BaseIO):
                 coords,
                 transform,
             )
+            if location is not None and direction is not None:
+                quant_data.attrs["los_transform"] = los_transform
 
             quant_data = quant_data.assign_coords(x=("channel", x_coord))
             quant_data = quant_data.assign_coords(y=("channel", y_coord))

--- a/indica/readers/read_st40.py
+++ b/indica/readers/read_st40.py
@@ -312,3 +312,13 @@ def filter_general(data: DataArray, quantities: list, lim: tuple = (-np.inf, np.
 
 def astra_equilibrium(pulse: int, revision: RevisionLike):
     """Assign ASTRA to equilibrium class"""
+
+
+def read_cxff_pi():
+    import indica.readers.read_st40 as read_st40
+    st40 = read_st40.ReadST40(10607)
+    st40(["cxff_pi"])
+    st40.raw_data["cxff_pi"]["ti"].los_transform.set_equilibrium(
+        st40.raw_data["cxff_pi"]["ti"].transform.equilibrium
+    )
+    st40.raw_data["cxff_pi"]["ti"].los_transform.plot_los(plot_all=True)

--- a/indica/readers/read_st40.py
+++ b/indica/readers/read_st40.py
@@ -316,6 +316,7 @@ def astra_equilibrium(pulse: int, revision: RevisionLike):
 
 def read_cxff_pi():
     import indica.readers.read_st40 as read_st40
+
     st40 = read_st40.ReadST40(10607)
     st40(["cxff_pi"])
     st40.raw_data["cxff_pi"]["ti"].los_transform.set_equilibrium(

--- a/indica/readers/st40reader.py
+++ b/indica/readers/st40reader.py
@@ -684,15 +684,19 @@ class ST40Reader(DataReader):
 
         texp, texp_path = self._get_signal(uid, instrument, ":exposure", revision)
         times, _ = self._get_signal(uid, instrument, ":time", revision)
-        # location, location_path = self._get_signal(
-        #     uid, instrument, ".geometry:location", revision
-        # )
-        # direction, direction_path = self._get_signal(
-        #     uid, instrument, ".geometry:direction", revision
-        # )
-        # if len(np.shape(location)) == 1:
-        #     location = np.array([location])
-        #     direction = np.array([direction])
+        try:
+            location, location_path = self._get_signal(
+                uid, instrument, ".geometry:location", revision
+            )
+            direction, direction_path = self._get_signal(
+                uid, instrument, ".geometry:direction", revision
+            )
+            if len(np.shape(location)) == 1:
+                location = np.array([location])
+                direction = np.array([direction])
+        except TreeNNF:
+            location = None
+            direction = None
 
         x, x_path = self._get_signal(uid, instrument, ":x", revision)
         y, y_path = self._get_signal(uid, instrument, ":y", revision)
@@ -727,8 +731,8 @@ class ST40Reader(DataReader):
         results["times"] = times
         results["texp"] = texp
         results["element"] = ""
-        # results["location"] = location
-        # results["direction"] = direction
+        results["location"] = location
+        results["direction"] = direction
 
         return results
 

--- a/tests/unit/readers/test_st40reader.py
+++ b/tests/unit/readers/test_st40reader.py
@@ -1,6 +1,6 @@
 from indica.readers import ST40Reader
 
-PULSE = 9229
+PULSE = 10605
 TSTART = 0.01
 TEND = 0.1
 
@@ -14,6 +14,8 @@ INSTRUMENT_INFO: dict = {
     "smmh1": ("interferom", "smmh1", 0, set()),
     "nirh1": ("interferom", "nirh1", 0, set()),
     "efit": ("", "efit", 0, set()),
+    "cxff_pi": ("", "cxff_pi", 0, set()),
+    "cxff_tws_c": ("", "cxff_tws_c", 0, set()),
 }
 
 
@@ -25,7 +27,7 @@ def run_reader_get_methods(
     General test script to read data from MDS+ and calculate LOS information
     including Cartesian-flux surface mapping
 
-    TODO: currently only runs, but no assertions to check what data it returns
+    TODO: Not testing MDS+ reading as tests currently using mock reader!!!
 
     Parameters
     ----------
@@ -123,5 +125,15 @@ def test_nirh1(instrument_name: str = "nirh1"):
 
 
 def test_efit(instrument_name: str = "efit"):
+    data, database_results = run_reader_get_methods(instrument_name)
+    check_transforms(instrument_name, data)
+
+
+def test_cxff_pi(instrument_name: str = "cxff_pi"):
+    data, database_results = run_reader_get_methods(instrument_name)
+    check_transforms(instrument_name, data)
+
+
+def test_cxff_tws_c(instrument_name: str = "cxff_tws_c"):
     data, database_results = run_reader_get_methods(instrument_name)
     check_transforms(instrument_name, data)


### PR DESCRIPTION
Modified reader to read in GEOMETRY from CXRS trees.
Still a temporary fix, with two transforms saved as attributes of each DataArray quantity:
- LOS_TRANSFORM = line-of-sight coming using GEOMETRY information Location and Direction
- TRANSFORM == TRANSECT transform using R and z positions of measurement as written in MDS+.

This can be used as is. We'll then search a solution to deal with different transforms.