### PR TITLE
Update default SAL host

### DIFF
--- a/indica/readers/jetreader.py
+++ b/indica/readers/jetreader.py
@@ -39,7 +39,7 @@ class JETReader(DataReader):
         tend: float,
         machine_conf: MachineConf = JETConf,
         reader_utils: BaseIO = SALUtils,
-        server: str = "https://sal.jet.uk",
+        server: str = "https://sal.jetdata.eu",
         verbose: bool = False,
         default_error: float = 0.05,
         *args,

--- a/indica/readers/salutils.py
+++ b/indica/readers/salutils.py
@@ -37,7 +37,7 @@ class SALWarning(UserWarning):
 
 
 class SALUtils(BaseIO):
-    def __init__(self, pulse: int, server: str = "https://sal.jet.uk"):
+    def __init__(self, pulse: int, server: str = "https://sal.jetdata.eu"):
         self.pulse = pulse
         self._reader_cache_id = f"ppf:{server.replace('-', '_')}:{pulse}"
         self._client = SALClient(server)


### PR DESCRIPTION
sal.jet.uk is being shut down so switch default server to sal.jetdata.eu