### PR TITLE
InDiCA eqdskreader.py NaN bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ indica/git_version
 *.prof
 *.lprof
 .ropeproject/
+.venv

--- a/indica/readers/eqdskreader.py
+++ b/indica/readers/eqdskreader.py
@@ -29,9 +29,17 @@ class EQDSKReader:
         xpsin = (psirz - gf.psi_axis) / (gf.psi_boundary - gf.psi_axis)
         _rmj = DataArray(
             R, coords={"xpsin": xpsin.interp(z=gf.zmagx).data}, dims=("xpsin",)
-        ).drop_duplicates("xpsin", keep=False)
-        rmjo = _rmj.where((_rmj >= gf.rmaxis), drop=True).interp(xpsin=psin)
-        rmji = _rmj.where((_rmj < gf.rmaxis), drop=True).interp(xpsin=psin)
+        )
+        rmjo = (
+            _rmj.where((_rmj >= gf.rmaxis), drop=True)
+            .drop_duplicates("xpsin", keep="first")
+            .interp(xpsin=psin)
+        )
+        rmji = (
+            _rmj.where((_rmj < gf.rmaxis), drop=True)
+            .drop_duplicates("xpsin", keep="last")
+            .interp(xpsin=psin)
+        )
         fpol = DataArray(gf.fpol, coords={"xpsin": psin}, dims=("xpsin",))
         qpsi = gf.qpsi
         ftor = xr.zeros_like(fpol)


### PR DESCRIPTION
Issue:
Some .eqdsk files feature repeated values of `psi=0` outside the LCFS. These translated to repeated values of `xpsin>1` outside the LCFS (since psi_boundary < 0) where psi=0, inboard and outboard of the LCFS. Previously, where `rmji` and `rmjo` were defined, locations with associated values of `xpsin` that were duplicates were all dropped (`.drop_duplicates(keep=False)`). These were all outside the LCFS, where `xpsin>1`. Subsequent interpolation onto the `psin` linspace (which runs from 0 to 1) lead to NaNs being returned for the `psin` values between the greatest `xpsin` value (e.g. 0.99) and 1.
Another downstream problem with having `max(xpsin)<1` is demonstrated by the `CoordinateTransform.get_equilibrium_boundaries()` method, which features the following interaction with the `Equilibrium` instance for a given `CoordinateTransform`:
```Python
R_hfs = self.equilibrium.rmji.sel(t=t, rhop=1, method="nearest").values
R_lfs = self.equilibrium.rmjo.sel(t=t, rhop=1, method="nearest").values
```
Here, the method attempts to find the major radial positions of the inner and outer LCFSs by interpolating `rmji` and `rmjo` at the point where `rhop=1`.  Since `rhop = sqrt(xpsin)`, and `max(xpsin)<1`, a NaN will be returned for the equilibrium boundaries.
Fix:
More careful use of `drop_duplicates` in the lines where `rmji` and `rmjo` are defined.  Split `_rmj` into inboard and outboard parts before dropping duplicates.  Then, drop locations where `xpsin` is duplicated, keeping the last appearance when walking major-radially outward for `rmji`, and keeping the first appearance when walking major-radially outwards for `rmjo`. One value of `_rmj` where `xpsin > 1` should be retained as the first element (during the creation of `rmji`) and last element (when making `rmjo`).  This ensures that no NaNs will be produced in the subsequent interpolation step, as the maximum possible query point (`psin=1`) will be less than the maximum retained `xpsin` value (>1).